### PR TITLE
feat: add interactive TUI and SQLite-backed spend tracking (V1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,6 +1501,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -2036,6 +2048,21 @@
         }
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -2339,6 +2366,69 @@
         }
       }
     },
+    "node_modules/ink-select-input": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
+      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "figures": "^6.1.0",
+        "to-rotated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-table": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ink-table/-/ink-table-3.1.0.tgz",
+      "integrity": "sha512-qxVb4DIaEaJryvF9uZGydnmP9Hkmas3DCKVpEcBYC0E4eJd3qNgNe+PZKuzgCERFe9LfAS1TNWxCr9+AU4v3YA==",
+      "license": "MIT",
+      "dependencies": {
+        "object-hash": "^2.0.3"
+      },
+      "peerDependencies": {
+        "ink": ">=3.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5",
+        "react": ">=18"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -2389,6 +2479,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2624,6 +2726,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -3525,6 +3636,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-rotated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
+      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3961,6 +4084,10 @@
         "@chainvault/core": "*",
         "commander": "^13.0.0",
         "ink": "^5.2.0",
+        "ink-select-input": "^6.2.0",
+        "ink-spinner": "^5.0.0",
+        "ink-table": "^3.1.0",
+        "ink-text-input": "^6.0.0",
         "react": "^18.3.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -973,6 +973,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1269,6 +1279,60 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1291,6 +1355,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1379,6 +1467,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
@@ -1564,6 +1658,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1574,6 +1683,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1581,6 +1699,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1616,6 +1743,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/environment": {
@@ -1780,6 +1916,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1891,6 +2036,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1929,6 +2080,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2002,6 +2159,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -2084,6 +2247,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -2100,6 +2283,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ink": {
@@ -2349,6 +2538,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2374,6 +2590,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2381,6 +2603,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -2582,6 +2816,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2593,6 +2854,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2634,6 +2905,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2660,6 +2946,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -2748,6 +3048,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2761,6 +3081,18 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -2920,6 +3252,51 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
@@ -2996,6 +3373,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -3028,6 +3414,15 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -3039,6 +3434,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -3111,6 +3534,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -3166,6 +3601,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3534,8 +3975,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",
+        "better-sqlite3": "^12.8.0",
         "viem": "^2.30.0",
         "zod": "^3.25.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13"
       }
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,9 +13,13 @@
   },
   "dependencies": {
     "@chainvault/core": "*",
+    "commander": "^13.0.0",
     "ink": "^5.2.0",
-    "react": "^18.3.0",
-    "commander": "^13.0.0"
+    "ink-select-input": "^6.2.0",
+    "ink-spinner": "^5.0.0",
+    "ink-table": "^3.1.0",
+    "ink-text-input": "^6.0.0",
+    "react": "^18.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,4 +61,13 @@ agentCmd
     console.log(result);
   });
 
-program.parse();
+if (process.argv.length <= 2) {
+  // No command args: launch TUI
+  const { render } = await import('ink');
+  const React = await import('react');
+  const { App } = await import('./tui/App.js');
+  const basePath = process.env.CHAINVAULT_PATH || DEFAULT_PATH;
+  render(React.createElement(App, { basePath }));
+} else {
+  program.parse();
+}

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -1,0 +1,208 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import {
+  MasterVault,
+  AgentVaultManager,
+  ChainVaultDB,
+  AuditStore,
+} from '@chainvault/core';
+
+import { PasswordPrompt } from './components/PasswordPrompt.js';
+import { MainMenu, type Screen } from './components/MainMenu.js';
+import { Dashboard } from './screens/Dashboard.js';
+import { KeysScreen } from './screens/KeysScreen.js';
+import { AgentsScreen } from './screens/AgentsScreen.js';
+import { ServicesScreen } from './screens/ServicesScreen.js';
+import { LogsScreen } from './screens/LogsScreen.js';
+import { RulesScreen } from './screens/RulesScreen.js';
+
+const AUTO_LOCK_MS = 15 * 60 * 1000; // 15 minutes
+const CHECK_INTERVAL_MS = 10 * 1000; // 10 seconds
+
+interface AppProps {
+  basePath: string;
+}
+
+export function App({ basePath }: AppProps) {
+  const [vault, setVault] = useState<MasterVault | null>(null);
+  const [screen, setScreen] = useState<Screen | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  const lastActivity = useRef(Date.now());
+  const dbRef = useRef<ChainVaultDB | null>(null);
+  const auditStoreRef = useRef<AuditStore | null>(null);
+
+  // Initialize DB and AuditStore once
+  useEffect(() => {
+    if (!dbRef.current) {
+      const db = new ChainVaultDB(basePath);
+      dbRef.current = db;
+      auditStoreRef.current = new AuditStore(db);
+    }
+    return () => {
+      dbRef.current?.close();
+    };
+  }, [basePath]);
+
+  // Auto-lock timer
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (vault && Date.now() - lastActivity.current > AUTO_LOCK_MS) {
+        vault.lock();
+        setVault(null);
+        setScreen(null);
+        setError(null);
+      }
+    }, CHECK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [vault]);
+
+  // Reset activity on any input
+  useInput(() => {
+    lastActivity.current = Date.now();
+  });
+
+  const refresh = useCallback(() => {
+    setRefreshCounter((c) => c + 1);
+  }, []);
+
+  const handlePasswordSubmit = useCallback(async (password: string) => {
+    try {
+      const v = await MasterVault.unlock(basePath, password);
+      setVault(v);
+      setError(null);
+      lastActivity.current = Date.now();
+    } catch {
+      setError('Wrong password');
+    }
+  }, [basePath]);
+
+  const handleBack = useCallback(() => {
+    setScreen(null);
+    refresh();
+  }, [refresh]);
+
+  // Locked state: show password prompt
+  if (!vault) {
+    return <PasswordPrompt onSubmit={handlePasswordSubmit} error={error ?? undefined} />;
+  }
+
+  // Menu state: show main menu
+  if (screen === null) {
+    const keys = vault.listKeys();
+    const agentManager = new AgentVaultManager(basePath, vault);
+    const agents = agentManager.listAgents();
+
+    return (
+      <MainMenu
+        keyCount={keys.length}
+        agentCount={agents.length}
+        onSelect={setScreen}
+      />
+    );
+  }
+
+  // Screen routing
+  const agentManager = new AgentVaultManager(basePath, vault);
+  const auditStore = auditStoreRef.current!;
+
+  switch (screen) {
+    case 'dashboard': {
+      const keys = vault.listKeys();
+      const agents = agentManager.listAgents();
+      const rpcEndpoints = vault.listRpcEndpoints();
+      const recentActivity = auditStore.getEntries(undefined, 10);
+      return (
+        <Dashboard
+          vaultPath={basePath}
+          keyCount={keys.length}
+          agentCount={agents.length}
+          rpcCount={rpcEndpoints.length}
+          recentActivity={recentActivity}
+          onBack={handleBack}
+        />
+      );
+    }
+    case 'keys': {
+      const keys = vault.listKeys();
+      return (
+        <KeysScreen
+          keys={keys}
+          onAddKey={async (name, privateKey, chains) => {
+            await vault.addKey(name, privateKey, chains);
+            refresh();
+          }}
+          onRemoveKey={async (name) => {
+            await vault.removeKey(name);
+            refresh();
+          }}
+          onBack={handleBack}
+        />
+      );
+    }
+    case 'agents': {
+      const agents = agentManager.listAgents();
+      return (
+        <AgentsScreen
+          agents={agents}
+          masterVault={vault}
+          agentManager={agentManager}
+          onBack={handleBack}
+        />
+      );
+    }
+    case 'services': {
+      const apiKeys = vault.listApiKeys();
+      const rpcEndpoints = vault.listRpcEndpoints();
+      return (
+        <ServicesScreen
+          apiKeys={apiKeys}
+          rpcEndpoints={rpcEndpoints}
+          onAddApiKey={async (name, key, url) => {
+            await vault.addApiKey(name, key, url);
+            refresh();
+          }}
+          onRemoveApiKey={async (name) => {
+            await vault.removeApiKey(name);
+            refresh();
+          }}
+          onAddRpcEndpoint={async (name, url, chainId) => {
+            await vault.addRpcEndpoint(name, url, chainId);
+            refresh();
+          }}
+          onRemoveRpcEndpoint={async (name) => {
+            await vault.removeRpcEndpoint(name);
+            refresh();
+          }}
+          onBack={handleBack}
+        />
+      );
+    }
+    case 'logs': {
+      return (
+        <LogsScreen
+          auditStore={auditStore}
+          onBack={handleBack}
+        />
+      );
+    }
+    case 'rules': {
+      const agents = agentManager.listAgents();
+      return (
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={handleBack}
+        />
+      );
+    }
+    default: {
+      return (
+        <Box>
+          <Text color="red">Unknown screen: {screen}</Text>
+        </Box>
+      );
+    }
+  }
+}

--- a/packages/cli/src/tui/components/MainMenu.tsx
+++ b/packages/cli/src/tui/components/MainMenu.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export type Screen = 'dashboard' | 'keys' | 'agents' | 'services' | 'logs' | 'rules';
+
+const MENU_ITEMS: { label: string; value: Screen }[] = [
+  { label: 'Dashboard', value: 'dashboard' },
+  { label: 'Keys', value: 'keys' },
+  { label: 'Agents', value: 'agents' },
+  { label: 'Services', value: 'services' },
+  { label: 'Logs', value: 'logs' },
+  { label: 'Rules', value: 'rules' },
+];
+
+interface MainMenuProps {
+  agentCount: number;
+  keyCount: number;
+  onSelect: (screen: Screen) => void;
+}
+
+export function MainMenu({ agentCount, keyCount, onSelect }: MainMenuProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useInput((input, key) => {
+    if (key.upArrow) setSelectedIndex((i) => (i > 0 ? i - 1 : MENU_ITEMS.length - 1));
+    if (key.downArrow) setSelectedIndex((i) => (i < MENU_ITEMS.length - 1 ? i + 1 : 0));
+    if (key.return) onSelect(MENU_ITEMS[selectedIndex].value);
+    if (input === 'q') process.exit(0);
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box marginBottom={1}>
+        <Text bold>ChainVault MCP</Text>
+        <Text dimColor> — {keyCount} keys, {agentCount} agents</Text>
+      </Box>
+      {MENU_ITEMS.map((item, i) => (
+        <Box key={item.value}>
+          <Text color={i === selectedIndex ? 'cyan' : undefined} bold={i === selectedIndex}>
+            {i === selectedIndex ? '> ' : '  '}{item.label}
+          </Text>
+        </Box>
+      ))}
+      <Box marginTop={1}>
+        <Text dimColor>arrows navigate / Enter select / q quit</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/components/PasswordPrompt.test.ts
+++ b/packages/cli/src/tui/components/PasswordPrompt.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { validatePassword } from './PasswordPrompt.js';
+
+describe('validatePassword', () => {
+  it('rejects empty password', () => {
+    expect(validatePassword('')).toBe('Password cannot be empty');
+  });
+
+  it('accepts non-empty password', () => {
+    expect(validatePassword('test')).toBe(null);
+  });
+});

--- a/packages/cli/src/tui/components/PasswordPrompt.tsx
+++ b/packages/cli/src/tui/components/PasswordPrompt.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+interface PasswordPromptProps {
+  onSubmit: (password: string) => void;
+  error?: string;
+}
+
+export function validatePassword(password: string): string | null {
+  if (!password) return 'Password cannot be empty';
+  return null;
+}
+
+export function PasswordPrompt({ onSubmit, error }: PasswordPromptProps) {
+  const [password, setPassword] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (key.return) {
+      const err = validatePassword(password);
+      if (err) { setValidationError(err); return; }
+      onSubmit(password);
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setPassword((prev) => prev.slice(0, -1));
+      setValidationError(null);
+      return;
+    }
+    if (input && !key.ctrl && !key.meta) {
+      setPassword((prev) => prev + input);
+      setValidationError(null);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>ChainVault</Text>
+      <Text> </Text>
+      <Text>Enter master vault password:</Text>
+      <Box>
+        <Text>{'> '}</Text>
+        <Text>{'*'.repeat(password.length)}</Text>
+        <Text dimColor>{'█'}</Text>
+      </Box>
+      {(error || validationError) && (
+        <Text color="red">{error || validationError}</Text>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/AgentsScreen.tsx
+++ b/packages/cli/src/tui/screens/AgentsScreen.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { MasterVault, AgentVaultManager, AgentConfig } from '@chainvault/core';
+
+interface AgentsScreenProps {
+  agents: Array<{ name: string; chains: number[]; allowed_types: string[] }>;
+  masterVault: MasterVault;
+  agentManager: AgentVaultManager;
+  onBack: () => void;
+}
+
+type Mode = 'list' | 'create-name' | 'create-chains' | 'create-types' | 'confirm-revoke' | 'show-key';
+
+const VALID_TX_TYPES = ['deploy', 'write', 'transfer', 'read', 'simulate'];
+
+export type { AgentsScreenProps };
+
+export function AgentsScreen({ agents, masterVault, agentManager, onBack }: AgentsScreenProps) {
+  const [mode, setMode] = useState<Mode>('list');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [nameInput, setNameInput] = useState('');
+  const [chainsInput, setChainsInput] = useState('');
+  const [typesInput, setTypesInput] = useState('');
+  const [vaultKey, setVaultKey] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (mode === 'list') {
+      if (key.escape) { onBack(); return; }
+      if (key.upArrow) { setSelectedIndex((p) => Math.max(0, p - 1)); return; }
+      if (key.downArrow) { setSelectedIndex((p) => Math.min(agents.length - 1, p + 1)); return; }
+      if (input === 'a') {
+        setNameInput(''); setChainsInput(''); setTypesInput(''); setError(null);
+        setMode('create-name');
+        return;
+      }
+      if (input === 'd' && agents.length > 0) {
+        setError(null);
+        setMode('confirm-revoke');
+        return;
+      }
+      return;
+    }
+
+    if (mode === 'create-name') {
+      if (key.escape) { setMode('list'); return; }
+      if (key.return) {
+        if (!nameInput.trim()) { setError('Name cannot be empty'); return; }
+        setError(null); setMode('create-chains');
+        return;
+      }
+      if (key.backspace || key.delete) { setNameInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setNameInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'create-chains') {
+      if (key.escape) { setMode('create-name'); return; }
+      if (key.return) {
+        const trimmed = chainsInput.trim();
+        if (!trimmed) { setError('Chain IDs cannot be empty'); return; }
+        const parts = trimmed.split(',').map((s) => s.trim());
+        for (const part of parts) {
+          const n = Number(part);
+          if (!Number.isInteger(n) || n <= 0) { setError(`Invalid chain ID: ${part}`); return; }
+        }
+        setError(null); setMode('create-types');
+        return;
+      }
+      if (key.backspace || key.delete) { setChainsInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setChainsInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'create-types') {
+      if (key.escape) { setMode('create-chains'); return; }
+      if (key.return) {
+        const trimmed = typesInput.trim();
+        if (!trimmed) { setError('Tx types cannot be empty'); return; }
+        const types = trimmed.split(',').map((s) => s.trim());
+        for (const t of types) {
+          if (!VALID_TX_TYPES.includes(t)) { setError(`Invalid tx type: ${t}`); return; }
+        }
+        setError(null);
+        const chains = chainsInput.trim().split(',').map((s) => Number(s.trim()));
+        const config: AgentConfig = {
+          name: nameInput.trim(),
+          chains,
+          tx_rules: { allowed_types: types as AgentConfig['tx_rules']['allowed_types'], limits: {} },
+          api_access: {},
+          contract_rules: { mode: 'none' },
+        };
+        agentManager.createAgent(config, [], [])
+          .then(({ vaultKey: key_ }) => {
+            setVaultKey(key_);
+            setMode('show-key');
+          })
+          .catch((err: unknown) => {
+            setError(err instanceof Error ? err.message : String(err));
+          });
+        return;
+      }
+      if (key.backspace || key.delete) { setTypesInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setTypesInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'show-key') {
+      setVaultKey('');
+      setMode('list');
+      return;
+    }
+
+    if (mode === 'confirm-revoke') {
+      if (key.escape || input === 'n') { setMode('list'); return; }
+      if (input === 'y') {
+        const agentName = agents[selectedIndex]?.name;
+        if (agentName) {
+          agentManager.revokeAgent(agentName)
+            .then(() => {
+              setSelectedIndex((p) => Math.min(p, agents.length - 2));
+              setMode('list');
+            })
+            .catch((err: unknown) => {
+              setError(err instanceof Error ? err.message : String(err));
+              setMode('list');
+            });
+        }
+        return;
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Agents</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+
+      {mode === 'list' && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            {agents.length === 0 ? (
+              <Text dimColor>  No agents configured</Text>
+            ) : (
+              agents.map((a, i) => (
+                <Text key={a.name}>
+                  <Text color={i === selectedIndex ? 'cyan' : undefined}>
+                    {i === selectedIndex ? '> ' : '  '}
+                  </Text>
+                  <Text bold={i === selectedIndex}>{a.name}</Text>
+                  <Text dimColor> chains=[{a.chains.join(',')}] types=[{a.allowed_types.join(',')}]</Text>
+                </Text>
+              ))
+            )}
+          </Box>
+          <Box marginTop={1}><Text dimColor>a add  d revoke  ↑↓ navigate  Esc back</Text></Box>
+        </>
+      )}
+
+      {mode === 'create-name' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Agent name:</Text>
+          <Box><Text>{'> '}</Text><Text>{nameInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'create-chains' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Chain IDs (comma-separated):</Text>
+          <Box><Text>{'> '}</Text><Text>{chainsInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'create-types' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Tx types (comma-separated: deploy,write,transfer,read,simulate):</Text>
+          <Box><Text>{'> '}</Text><Text>{typesInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'show-key' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color="yellow" bold>WARNING: Save this vault key now. It cannot be recovered.</Text>
+          <Box marginTop={1}><Text>Vault Key: </Text><Text color="green">{vaultKey}</Text></Box>
+          <Box marginTop={1}><Text dimColor>Press any key to continue</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'confirm-revoke' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Revoke agent &apos;{agents[selectedIndex]?.name}&apos;? (y/n)</Text>
+        </Box>
+      )}
+
+      {error && <Text color="red">{error}</Text>}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/Dashboard.tsx
+++ b/packages/cli/src/tui/screens/Dashboard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { AuditEntry } from '@chainvault/core';
+
+interface DashboardProps {
+  vaultPath: string;
+  keyCount: number;
+  agentCount: number;
+  rpcCount: number;
+  recentActivity: AuditEntry[];
+  onBack: () => void;
+}
+
+export function Dashboard({ vaultPath, keyCount, agentCount, rpcCount, recentActivity, onBack }: DashboardProps) {
+  useInput((_input, key) => { if (key.escape) onBack(); });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Dashboard</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Text>Vault: <Text color="green">unlocked</Text></Text>
+        <Text>Path:  <Text dimColor>{vaultPath}</Text></Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Resources</Text>
+        <Text>  Keys:      {keyCount}</Text>
+        <Text>  Agents:    {agentCount}</Text>
+        <Text>  Endpoints: {rpcCount}</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Recent Activity</Text>
+        {recentActivity.length === 0 ? (
+          <Text dimColor>  No activity yet</Text>
+        ) : (
+          recentActivity.slice(0, 10).map((entry, i) => (
+            <Text key={i}>
+              <Text dimColor>{entry.timestamp.slice(11, 19)} </Text>
+              <Text color={entry.status === 'approved' ? 'green' : 'red'}>
+                {entry.status === 'approved' ? '+' : 'x'}
+              </Text>
+              <Text> {entry.agent} {entry.action}</Text>
+            </Text>
+          ))
+        )}
+      </Box>
+      <Box marginTop={1}><Text dimColor>Esc back</Text></Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/KeysScreen.tsx
+++ b/packages/cli/src/tui/screens/KeysScreen.tsx
@@ -1,0 +1,253 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+interface KeyInfo {
+  name: string;
+  address: string;
+  chains: number[];
+}
+
+interface KeysScreenProps {
+  keys: KeyInfo[];
+  onAddKey: (name: string, privateKey: string, chains: number[]) => Promise<void>;
+  onRemoveKey: (name: string) => Promise<void>;
+  onBack: () => void;
+}
+
+type Mode = 'list' | 'add-name' | 'add-key' | 'add-chains' | 'confirm-delete';
+
+export type { KeyInfo, KeysScreenProps };
+
+export function KeysScreen({ keys, onAddKey, onRemoveKey, onBack }: KeysScreenProps) {
+  const [mode, setMode] = useState<Mode>('list');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [nameInput, setNameInput] = useState('');
+  const [keyInput, setKeyInput] = useState('');
+  const [chainsInput, setChainsInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (mode === 'list') {
+      if (key.escape) {
+        onBack();
+        return;
+      }
+      if (key.upArrow) {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setSelectedIndex((prev) => Math.min(keys.length - 1, prev + 1));
+        return;
+      }
+      if (input === 'a') {
+        setMode('add-name');
+        setNameInput('');
+        setKeyInput('');
+        setChainsInput('');
+        setError(null);
+        return;
+      }
+      if (input === 'd' && keys.length > 0) {
+        setError(null);
+        setMode('confirm-delete');
+        return;
+      }
+      return;
+    }
+
+    if (mode === 'add-name') {
+      if (key.escape) {
+        setMode('list');
+        return;
+      }
+      if (key.return) {
+        if (!nameInput.trim()) {
+          setError('Name cannot be empty');
+          return;
+        }
+        setError(null);
+        setMode('add-key');
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setNameInput((prev) => prev.slice(0, -1));
+        setError(null);
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setNameInput((prev) => prev + input);
+        setError(null);
+      }
+      return;
+    }
+
+    if (mode === 'add-key') {
+      if (key.escape) {
+        setMode('add-name');
+        return;
+      }
+      if (key.return) {
+        if (!keyInput.trim()) {
+          setError('Private key cannot be empty');
+          return;
+        }
+        setError(null);
+        setMode('add-chains');
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setKeyInput((prev) => prev.slice(0, -1));
+        setError(null);
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setKeyInput((prev) => prev + input);
+        setError(null);
+      }
+      return;
+    }
+
+    if (mode === 'add-chains') {
+      if (key.escape) {
+        setMode('add-key');
+        return;
+      }
+      if (key.return) {
+        const trimmed = chainsInput.trim();
+        if (!trimmed) {
+          setError('Chain IDs cannot be empty');
+          return;
+        }
+        const parts = trimmed.split(',').map((s) => s.trim());
+        const chains: number[] = [];
+        for (const part of parts) {
+          const n = Number(part);
+          if (!Number.isInteger(n) || n <= 0) {
+            setError(`Invalid chain ID: ${part}`);
+            return;
+          }
+          chains.push(n);
+        }
+        setError(null);
+        onAddKey(nameInput.trim(), keyInput.trim(), chains)
+          .then(() => {
+            setMode('list');
+            setNameInput('');
+            setKeyInput('');
+            setChainsInput('');
+          })
+          .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : String(err);
+            setError(message);
+          });
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setChainsInput((prev) => prev.slice(0, -1));
+        setError(null);
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setChainsInput((prev) => prev + input);
+        setError(null);
+      }
+      return;
+    }
+
+    if (mode === 'confirm-delete') {
+      if (key.escape || input === 'n') {
+        setMode('list');
+        return;
+      }
+      if (input === 'y') {
+        const keyName = keys[selectedIndex]?.name;
+        if (keyName) {
+          onRemoveKey(keyName)
+            .then(() => {
+              setSelectedIndex((prev) => Math.min(prev, keys.length - 2));
+              setMode('list');
+            })
+            .catch((err: unknown) => {
+              const message = err instanceof Error ? err.message : String(err);
+              setError(message);
+              setMode('list');
+            });
+        }
+        return;
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Keys</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+
+      {mode === 'list' && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            {keys.length === 0 ? (
+              <Text dimColor>  No keys stored</Text>
+            ) : (
+              keys.map((k, i) => (
+                <Text key={k.name}>
+                  <Text color={i === selectedIndex ? 'cyan' : undefined}>
+                    {i === selectedIndex ? '> ' : '  '}
+                  </Text>
+                  <Text bold={i === selectedIndex}>{k.name}</Text>
+                  <Text dimColor> {k.address} </Text>
+                  <Text dimColor>[{k.chains.join(', ')}]</Text>
+                </Text>
+              ))
+            )}
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>a add  d delete  ↑↓ navigate  Esc back</Text>
+          </Box>
+        </>
+      )}
+
+      {mode === 'add-name' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Key name:</Text>
+          <Box>
+            <Text>{'> '}</Text>
+            <Text>{nameInput}</Text>
+            <Text dimColor>{'█'}</Text>
+          </Box>
+        </Box>
+      )}
+
+      {mode === 'add-key' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Private key for &quot;{nameInput}&quot;:</Text>
+          <Box>
+            <Text>{'> '}</Text>
+            <Text>{'*'.repeat(keyInput.length)}</Text>
+            <Text dimColor>{'█'}</Text>
+          </Box>
+        </Box>
+      )}
+
+      {mode === 'add-chains' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Chain IDs (comma-separated):</Text>
+          <Box>
+            <Text>{'> '}</Text>
+            <Text>{chainsInput}</Text>
+            <Text dimColor>{'█'}</Text>
+          </Box>
+        </Box>
+      )}
+
+      {mode === 'confirm-delete' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Delete key &apos;{keys[selectedIndex]?.name}&apos;? (y/n)</Text>
+        </Box>
+      )}
+
+      {error && <Text color="red">{error}</Text>}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/LogsScreen.tsx
+++ b/packages/cli/src/tui/screens/LogsScreen.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useMemo } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { AuditStore, AuditEntry } from '@chainvault/core';
+
+interface LogsScreenProps {
+  auditStore: AuditStore;
+  onBack: () => void;
+}
+
+type FilterMode = 'all' | 'approved' | 'denied';
+const FILTER_ORDER: FilterMode[] = ['all', 'approved', 'denied'];
+const PAGE_SIZE = 15;
+
+export type { LogsScreenProps };
+
+export function LogsScreen({ auditStore, onBack }: LogsScreenProps) {
+  const [filter, setFilter] = useState<FilterMode>('all');
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const entries: AuditEntry[] = useMemo(() => {
+    const filterOpts = filter === 'all' ? undefined : { status: filter as 'approved' | 'denied' };
+    return auditStore.getEntries(filterOpts, 200);
+  }, [auditStore, filter]);
+
+  const visibleEntries = entries.slice(scrollOffset, scrollOffset + PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(entries.length / PAGE_SIZE));
+  const currentPage = Math.floor(scrollOffset / PAGE_SIZE) + 1;
+
+  useInput((input, key) => {
+    if (key.escape) { onBack(); return; }
+    if (key.upArrow) { setScrollOffset((p) => Math.max(0, p - 1)); return; }
+    if (key.downArrow) { setScrollOffset((p) => Math.min(Math.max(0, entries.length - PAGE_SIZE), p + 1)); return; }
+    if (input === 'f') {
+      const idx = FILTER_ORDER.indexOf(filter);
+      const next = FILTER_ORDER[(idx + 1) % FILTER_ORDER.length]!;
+      setFilter(next);
+      setScrollOffset(0);
+      return;
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Audit Logs</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+
+      <Box marginTop={1}>
+        <Text>Filter: </Text>
+        <Text color="cyan" bold>{filter}</Text>
+        <Text dimColor>  ({entries.length} entries, page {currentPage}/{totalPages})</Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        {entries.length === 0 ? (
+          <Text dimColor>  No log entries</Text>
+        ) : (
+          visibleEntries.map((entry, i) => (
+            <Text key={scrollOffset + i}>
+              <Text dimColor>{entry.timestamp.slice(0, 19)} </Text>
+              <Text color={entry.status === 'approved' ? 'green' : 'red'}>
+                {entry.status === 'approved' ? '+' : 'x'}
+              </Text>
+              <Text> {entry.agent} </Text>
+              <Text dimColor>{entry.action} chain:{entry.chain_id}</Text>
+              {entry.details ? <Text dimColor> {entry.details}</Text> : null}
+            </Text>
+          ))
+        )}
+      </Box>
+
+      <Box marginTop={1}><Text dimColor>f filter  ↑↓ scroll  Esc back</Text></Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/RulesScreen.tsx
+++ b/packages/cli/src/tui/screens/RulesScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { MasterVault } from '@chainvault/core';
+
+interface RulesScreenProps {
+  agents: Array<{ name: string; chains: number[]; allowed_types: string[] }>;
+  masterVault: MasterVault;
+  onBack: () => void;
+}
+
+type Mode = 'select-agent' | 'edit-menu' | 'edit-chains' | 'edit-types' | 'edit-limits';
+const MENU_ITEMS = ['Edit Chains', 'Edit Tx Types', 'Edit Limits', 'Back'] as const;
+const VALID_TX_TYPES = ['deploy', 'write', 'transfer', 'read', 'simulate'];
+
+export type { RulesScreenProps };
+
+export function RulesScreen({ agents, masterVault, onBack }: RulesScreenProps) {
+  const [mode, setMode] = useState<Mode>('select-agent');
+  const [selectedAgent, setSelectedAgent] = useState(0);
+  const [menuIndex, setMenuIndex] = useState(0);
+  const [chainsInput, setChainsInput] = useState('');
+  const [typesInput, setTypesInput] = useState('');
+  const [limitsInput, setLimitsInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const currentAgentName = agents[selectedAgent]?.name;
+
+  useInput((input, key) => {
+    if (mode === 'select-agent') {
+      if (key.escape) { onBack(); return; }
+      if (key.upArrow) { setSelectedAgent((p) => Math.max(0, p - 1)); return; }
+      if (key.downArrow) { setSelectedAgent((p) => Math.min(agents.length - 1, p + 1)); return; }
+      if (key.return && agents.length > 0) {
+        setMenuIndex(0); setError(null); setMessage(null);
+        setMode('edit-menu');
+        return;
+      }
+      return;
+    }
+
+    if (mode === 'edit-menu') {
+      if (key.escape) { setMode('select-agent'); return; }
+      if (key.upArrow) { setMenuIndex((p) => Math.max(0, p - 1)); return; }
+      if (key.downArrow) { setMenuIndex((p) => Math.min(MENU_ITEMS.length - 1, p + 1)); return; }
+      if (key.return) {
+        const item = MENU_ITEMS[menuIndex];
+        if (item === 'Back') { setMode('select-agent'); return; }
+        if (item === 'Edit Chains') {
+          const agent = agents[selectedAgent];
+          setChainsInput(agent ? agent.chains.join(',') : '');
+          setError(null); setMessage(null); setMode('edit-chains');
+          return;
+        }
+        if (item === 'Edit Tx Types') {
+          const agent = agents[selectedAgent];
+          setTypesInput(agent ? agent.allowed_types.join(',') : '');
+          setError(null); setMessage(null); setMode('edit-types');
+          return;
+        }
+        if (item === 'Edit Limits') {
+          setLimitsInput('');
+          setError(null); setMessage(null); setMode('edit-limits');
+          return;
+        }
+      }
+      return;
+    }
+
+    if (mode === 'edit-chains') {
+      if (key.escape) { setMode('edit-menu'); return; }
+      if (key.return) {
+        const trimmed = chainsInput.trim();
+        if (!trimmed) { setError('Chain IDs cannot be empty'); return; }
+        const parts = trimmed.split(',').map((s) => s.trim());
+        const chains: number[] = [];
+        for (const part of parts) {
+          const n = Number(part);
+          if (!Number.isInteger(n) || n <= 0) { setError(`Invalid chain ID: ${part}`); return; }
+          chains.push(n);
+        }
+        if (!currentAgentName) return;
+        const data = masterVault.getData();
+        const agentConfig = data.agents[currentAgentName];
+        if (agentConfig) {
+          agentConfig.chains = chains;
+          masterVault.saveData()
+            .then(() => { setMessage('Chains updated'); setMode('edit-menu'); })
+            .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); });
+        }
+        return;
+      }
+      if (key.backspace || key.delete) { setChainsInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setChainsInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'edit-types') {
+      if (key.escape) { setMode('edit-menu'); return; }
+      if (key.return) {
+        const trimmed = typesInput.trim();
+        if (!trimmed) { setError('Tx types cannot be empty'); return; }
+        const types = trimmed.split(',').map((s) => s.trim());
+        for (const t of types) {
+          if (!VALID_TX_TYPES.includes(t)) { setError(`Invalid tx type: ${t}`); return; }
+        }
+        if (!currentAgentName) return;
+        const data = masterVault.getData();
+        const agentConfig = data.agents[currentAgentName];
+        if (agentConfig) {
+          agentConfig.tx_rules.allowed_types = types as typeof agentConfig.tx_rules.allowed_types;
+          masterVault.saveData()
+            .then(() => { setMessage('Tx types updated'); setMode('edit-menu'); })
+            .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); });
+        }
+        return;
+      }
+      if (key.backspace || key.delete) { setTypesInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setTypesInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'edit-limits') {
+      if (key.escape) { setMode('edit-menu'); return; }
+      if (key.return) {
+        // Format: chainId:maxPerTx:daily:monthly (e.g. "1:1.0:10.0:100.0")
+        const trimmed = limitsInput.trim();
+        if (!trimmed) { setError('Limits cannot be empty (format: chainId:maxPerTx:daily:monthly)'); return; }
+        const parts = trimmed.split(':');
+        if (parts.length !== 4) { setError('Format: chainId:maxPerTx:daily:monthly'); return; }
+        const [chainId, maxPerTx, daily, monthly] = parts as [string, string, string, string];
+        const chainNum = Number(chainId);
+        if (!Number.isInteger(chainNum) || chainNum <= 0) { setError('Invalid chain ID'); return; }
+        if (!currentAgentName) return;
+        const data = masterVault.getData();
+        const agentConfig = data.agents[currentAgentName];
+        if (agentConfig) {
+          agentConfig.tx_rules.limits[String(chainNum)] = {
+            max_per_tx: maxPerTx,
+            daily_limit: daily,
+            monthly_limit: monthly,
+          };
+          masterVault.saveData()
+            .then(() => { setMessage('Limits updated'); setMode('edit-menu'); })
+            .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); });
+        }
+        return;
+      }
+      if (key.backspace || key.delete) { setLimitsInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setLimitsInput((p) => p + input); setError(null); }
+      return;
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Rules</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+
+      {mode === 'select-agent' && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text bold>Select agent to edit:</Text>
+            {agents.length === 0 ? (
+              <Text dimColor>  No agents configured</Text>
+            ) : (
+              agents.map((a, i) => (
+                <Text key={a.name}>
+                  <Text color={i === selectedAgent ? 'cyan' : undefined}>
+                    {i === selectedAgent ? '> ' : '  '}
+                  </Text>
+                  <Text bold={i === selectedAgent}>{a.name}</Text>
+                  <Text dimColor> chains=[{a.chains.join(',')}] types=[{a.allowed_types.join(',')}]</Text>
+                </Text>
+              ))
+            )}
+          </Box>
+          <Box marginTop={1}><Text dimColor>Enter select  ↑↓ navigate  Esc back</Text></Box>
+        </>
+      )}
+
+      {mode === 'edit-menu' && (
+        <>
+          <Box marginTop={1}><Text>Editing: <Text bold>{currentAgentName}</Text></Text></Box>
+          <Box marginTop={1} flexDirection="column">
+            {MENU_ITEMS.map((item, i) => (
+              <Text key={item}>
+                <Text color={i === menuIndex ? 'cyan' : undefined}>
+                  {i === menuIndex ? '> ' : '  '}
+                </Text>
+                <Text bold={i === menuIndex}>{item}</Text>
+              </Text>
+            ))}
+          </Box>
+          {message && <Box marginTop={1}><Text color="green">{message}</Text></Box>}
+          <Box marginTop={1}><Text dimColor>Enter select  ↑↓ navigate  Esc back</Text></Box>
+        </>
+      )}
+
+      {mode === 'edit-chains' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Chains for {currentAgentName} (comma-separated):</Text>
+          <Box><Text>{'> '}</Text><Text>{chainsInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'edit-types' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Tx types for {currentAgentName} (deploy,write,transfer,read,simulate):</Text>
+          <Box><Text>{'> '}</Text><Text>{typesInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'edit-limits' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Limits for {currentAgentName} (format: chainId:maxPerTx:daily:monthly):</Text>
+          <Box><Text>{'> '}</Text><Text>{limitsInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {error && <Text color="red">{error}</Text>}
+    </Box>
+  );
+}

--- a/packages/cli/src/tui/screens/ServicesScreen.tsx
+++ b/packages/cli/src/tui/screens/ServicesScreen.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+interface ServicesScreenProps {
+  apiKeys: Array<{ name: string; base_url: string }>;
+  rpcEndpoints: Array<{ name: string; url: string; chain_id: number }>;
+  onAddApiKey: (name: string, key: string, url: string) => Promise<void>;
+  onRemoveApiKey: (name: string) => Promise<void>;
+  onAddRpcEndpoint: (name: string, url: string, chainId: number) => Promise<void>;
+  onRemoveRpcEndpoint: (name: string) => Promise<void>;
+  onBack: () => void;
+}
+
+type Section = 'api' | 'rpc';
+type Mode = 'list' | 'add-name' | 'add-value' | 'add-url' | 'add-chain' | 'confirm-delete';
+
+export type { ServicesScreenProps };
+
+export function ServicesScreen({
+  apiKeys, rpcEndpoints,
+  onAddApiKey, onRemoveApiKey, onAddRpcEndpoint, onRemoveRpcEndpoint,
+  onBack,
+}: ServicesScreenProps) {
+  const [section, setSection] = useState<Section>('api');
+  const [mode, setMode] = useState<Mode>('list');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [nameInput, setNameInput] = useState('');
+  const [valueInput, setValueInput] = useState('');
+  const [urlInput, setUrlInput] = useState('');
+  const [chainInput, setChainInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const currentList = section === 'api' ? apiKeys : rpcEndpoints;
+
+  useInput((input, key) => {
+    if (mode === 'list') {
+      if (key.escape) { onBack(); return; }
+      if (key.tab) {
+        setSection((s) => s === 'api' ? 'rpc' : 'api');
+        setSelectedIndex(0); setError(null);
+        return;
+      }
+      if (key.upArrow) { setSelectedIndex((p) => Math.max(0, p - 1)); return; }
+      if (key.downArrow) { setSelectedIndex((p) => Math.min(currentList.length - 1, p + 1)); return; }
+      if (input === 'a') {
+        setNameInput(''); setValueInput(''); setUrlInput(''); setChainInput(''); setError(null);
+        setMode('add-name');
+        return;
+      }
+      if (input === 'd' && currentList.length > 0) {
+        setError(null); setMode('confirm-delete');
+        return;
+      }
+      return;
+    }
+
+    if (mode === 'add-name') {
+      if (key.escape) { setMode('list'); return; }
+      if (key.return) {
+        if (!nameInput.trim()) { setError('Name cannot be empty'); return; }
+        setError(null);
+        setMode(section === 'api' ? 'add-value' : 'add-url');
+        return;
+      }
+      if (key.backspace || key.delete) { setNameInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setNameInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    // API key flow: add-value -> add-url -> done
+    if (mode === 'add-value') {
+      if (key.escape) { setMode('add-name'); return; }
+      if (key.return) {
+        if (!valueInput.trim()) { setError('API key cannot be empty'); return; }
+        setError(null); setMode('add-url');
+        return;
+      }
+      if (key.backspace || key.delete) { setValueInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setValueInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'add-url') {
+      if (key.escape) { setMode(section === 'api' ? 'add-value' : 'add-name'); return; }
+      if (key.return) {
+        if (!urlInput.trim()) { setError('URL cannot be empty'); return; }
+        setError(null);
+        if (section === 'api') {
+          onAddApiKey(nameInput.trim(), valueInput.trim(), urlInput.trim())
+            .then(() => { setMode('list'); })
+            .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); });
+        } else {
+          setMode('add-chain');
+        }
+        return;
+      }
+      if (key.backspace || key.delete) { setUrlInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setUrlInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    // RPC flow: add-name -> add-url -> add-chain -> done
+    if (mode === 'add-chain') {
+      if (key.escape) { setMode('add-url'); return; }
+      if (key.return) {
+        const n = Number(chainInput.trim());
+        if (!Number.isInteger(n) || n <= 0) { setError('Invalid chain ID'); return; }
+        setError(null);
+        onAddRpcEndpoint(nameInput.trim(), urlInput.trim(), n)
+          .then(() => { setMode('list'); })
+          .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); });
+        return;
+      }
+      if (key.backspace || key.delete) { setChainInput((p) => p.slice(0, -1)); setError(null); return; }
+      if (input && !key.ctrl && !key.meta) { setChainInput((p) => p + input); setError(null); }
+      return;
+    }
+
+    if (mode === 'confirm-delete') {
+      if (key.escape || input === 'n') { setMode('list'); return; }
+      if (input === 'y') {
+        const item = currentList[selectedIndex];
+        if (item) {
+          const promise = section === 'api'
+            ? onRemoveApiKey(item.name)
+            : onRemoveRpcEndpoint(item.name);
+          promise
+            .then(() => { setSelectedIndex((p) => Math.min(p, currentList.length - 2)); setMode('list'); })
+            .catch((err: unknown) => { setError(err instanceof Error ? err.message : String(err)); setMode('list'); });
+        }
+        return;
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Services</Text>
+      <Text dimColor>{'─'.repeat(40)}</Text>
+
+      {mode === 'list' && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text bold color={section === 'api' ? 'cyan' : undefined}>API Keys</Text>
+            {apiKeys.length === 0 ? (
+              <Text dimColor>  No API keys</Text>
+            ) : (
+              apiKeys.map((a, i) => {
+                const active = section === 'api';
+                const sel = active && i === selectedIndex;
+                return (
+                  <Text key={a.name}>
+                    <Text color={sel ? 'cyan' : undefined}>{sel ? '> ' : '  '}</Text>
+                    <Text bold={sel}>{a.name}</Text>
+                    <Text dimColor> {a.base_url}</Text>
+                  </Text>
+                );
+              })
+            )}
+          </Box>
+
+          <Box marginTop={1} flexDirection="column">
+            <Text bold color={section === 'rpc' ? 'cyan' : undefined}>RPC Endpoints</Text>
+            {rpcEndpoints.length === 0 ? (
+              <Text dimColor>  No RPC endpoints</Text>
+            ) : (
+              rpcEndpoints.map((r, i) => {
+                const active = section === 'rpc';
+                const sel = active && i === selectedIndex;
+                return (
+                  <Text key={r.name}>
+                    <Text color={sel ? 'cyan' : undefined}>{sel ? '> ' : '  '}</Text>
+                    <Text bold={sel}>{r.name}</Text>
+                    <Text dimColor> {r.url} (chain {r.chain_id})</Text>
+                  </Text>
+                );
+              })
+            )}
+          </Box>
+
+          <Box marginTop={1}><Text dimColor>Tab switch  a add  d delete  ↑↓ navigate  Esc back</Text></Box>
+        </>
+      )}
+
+      {mode === 'add-name' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>{section === 'api' ? 'API key' : 'RPC endpoint'} name:</Text>
+          <Box><Text>{'> '}</Text><Text>{nameInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'add-value' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>API key value:</Text>
+          <Box><Text>{'> '}</Text><Text>{'*'.repeat(valueInput.length)}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'add-url' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>{section === 'api' ? 'Base URL' : 'RPC URL'}:</Text>
+          <Box><Text>{'> '}</Text><Text>{urlInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'add-chain' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Chain ID:</Text>
+          <Box><Text>{'> '}</Text><Text>{chainInput}</Text><Text dimColor>{'█'}</Text></Box>
+        </Box>
+      )}
+
+      {mode === 'confirm-delete' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>Delete {section === 'api' ? 'API key' : 'RPC endpoint'} &apos;{currentList[selectedIndex]?.name}&apos;? (y/n)</Text>
+        </Box>
+      )}
+
+      {error && <Text color="red">{error}</Text>}
+    </Box>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",
+    "better-sqlite3": "^12.8.0",
     "viem": "^2.30.0",
     "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13"
   }
 }

--- a/packages/core/src/chain/evm-adapter.ts
+++ b/packages/core/src/chain/evm-adapter.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, createWalletClient, http, formatEther, formatGwei, type PublicClient } from 'viem';
+import { createPublicClient, createWalletClient, http, formatEther, formatGwei, defineChain, type PublicClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import type {
   ChainAdapter,
@@ -102,10 +102,21 @@ export class EvmAdapter implements ChainAdapter {
     };
   }
 
+  private getChain() {
+    return defineChain({
+      id: this.chainId,
+      name: `Chain ${this.chainId}`,
+      nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+      rpcUrls: { default: { http: [this.rpcUrl] } },
+    });
+  }
+
   async deployContract(params: DeployParams): Promise<{ hash: string; address?: string }> {
     const account = privateKeyToAccount(params.privateKey as `0x${string}`);
+    const chain = this.getChain();
     const walletClient = createWalletClient({
       account,
+      chain,
       transport: http(this.rpcUrl),
     });
 
@@ -114,6 +125,7 @@ export class EvmAdapter implements ChainAdapter {
       bytecode: params.bytecode as `0x${string}`,
       args: params.args || [],
       account,
+      chain,
     });
 
     // Wait for receipt to get contract address
@@ -127,8 +139,10 @@ export class EvmAdapter implements ChainAdapter {
 
   async writeContract(params: WriteContractParams): Promise<{ hash: string }> {
     const account = privateKeyToAccount(params.privateKey as `0x${string}`);
+    const chain = this.getChain();
     const walletClient = createWalletClient({
       account,
+      chain,
       transport: http(this.rpcUrl),
     });
 
@@ -138,6 +152,7 @@ export class EvmAdapter implements ChainAdapter {
       functionName: params.functionName,
       args: params.args,
       account,
+      chain,
       value: params.value ? BigInt(params.value) : undefined,
     });
 

--- a/packages/core/src/db/audit-store.test.ts
+++ b/packages/core/src/db/audit-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ChainVaultDB } from './database.js';
+import { AuditStore, type AuditEntry } from './audit-store.js';
+
+describe('AuditStore', () => {
+  let testDir: string;
+  let db: ChainVaultDB;
+  let store: AuditStore;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'chainvault-audit-store-'));
+    db = new ChainVaultDB(testDir);
+    store = new AuditStore(db);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('logs an entry and retrieves it', () => {
+    store.log({
+      agent: 'deployer',
+      action: 'deploy_contract',
+      chain_id: 11155111,
+      status: 'approved',
+      details: 'Deployed to Sepolia',
+    });
+    const entries = store.getEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].agent).toBe('deployer');
+    expect(entries[0].status).toBe('approved');
+    expect(entries[0].timestamp).toBeDefined();
+  });
+
+  it('accumulates entries', () => {
+    store.log({ agent: 'a', action: 'read', chain_id: 1, status: 'approved', details: '' });
+    store.log({ agent: 'b', action: 'write', chain_id: 1, status: 'denied', details: '' });
+    expect(store.getEntries()).toHaveLength(2);
+  });
+
+  it('filters by agent', () => {
+    store.log({ agent: 'deployer', action: 'deploy', chain_id: 1, status: 'approved', details: '' });
+    store.log({ agent: 'reader', action: 'read', chain_id: 1, status: 'approved', details: '' });
+    const filtered = store.getEntries({ agent: 'deployer' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].agent).toBe('deployer');
+  });
+
+  it('filters by status', () => {
+    store.log({ agent: 'a', action: 'deploy', chain_id: 1, status: 'approved', details: '' });
+    store.log({ agent: 'a', action: 'write', chain_id: 1, status: 'denied', details: '' });
+    const denied = store.getEntries({ status: 'denied' });
+    expect(denied).toHaveLength(1);
+  });
+
+  it('returns entries with limit', () => {
+    for (let i = 0; i < 20; i++) {
+      store.log({ agent: 'a', action: `action-${i}`, chain_id: 1, status: 'approved', details: '' });
+    }
+    const limited = store.getEntries({}, 10);
+    expect(limited).toHaveLength(10);
+  });
+
+  it('persists across instances', () => {
+    store.log({ agent: 'a', action: 'test', chain_id: 1, status: 'approved', details: 'persist' });
+    const store2 = new AuditStore(db);
+    expect(store2.getEntries()).toHaveLength(1);
+  });
+});

--- a/packages/core/src/db/audit-store.ts
+++ b/packages/core/src/db/audit-store.ts
@@ -1,0 +1,61 @@
+import type { ChainVaultDB } from './database.js';
+
+export interface AuditEntry {
+  timestamp: string;
+  agent: string;
+  action: string;
+  chain_id: number;
+  status: 'approved' | 'denied';
+  details: string;
+}
+
+type LogInput = Omit<AuditEntry, 'timestamp'>;
+
+interface FilterOptions {
+  agent?: string;
+  status?: 'approved' | 'denied';
+}
+
+export class AuditStore {
+  private db: ChainVaultDB;
+
+  constructor(db: ChainVaultDB) {
+    this.db = db;
+  }
+
+  log(entry: LogInput): void {
+    this.db.getDB().prepare(
+      'INSERT INTO audit_entries (timestamp, agent, action, chain_id, status, details) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(
+      new Date().toISOString(),
+      entry.agent,
+      entry.action,
+      entry.chain_id,
+      entry.status,
+      entry.details,
+    );
+  }
+
+  getEntries(filter?: FilterOptions, limit?: number): AuditEntry[] {
+    let sql = 'SELECT timestamp, agent, action, chain_id, status, details FROM audit_entries WHERE 1=1';
+    const params: any[] = [];
+
+    if (filter?.agent) {
+      sql += ' AND agent = ?';
+      params.push(filter.agent);
+    }
+    if (filter?.status) {
+      sql += ' AND status = ?';
+      params.push(filter.status);
+    }
+
+    sql += ' ORDER BY id DESC';
+
+    if (limit) {
+      sql += ' LIMIT ?';
+      params.push(limit);
+    }
+
+    return this.db.getDB().prepare(sql).all(...params) as AuditEntry[];
+  }
+}

--- a/packages/core/src/db/database.test.ts
+++ b/packages/core/src/db/database.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ChainVaultDB } from './database.js';
+
+describe('ChainVaultDB', () => {
+  let testDir: string;
+  let db: ChainVaultDB;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'chainvault-db-'));
+    db = new ChainVaultDB(testDir);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('creates database file', async () => {
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(join(testDir, 'chainvault.db'))).toBe(true);
+  });
+
+  it('creates spend_records table', () => {
+    const tables = db.getDB().prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='spend_records'"
+    ).all();
+    expect(tables).toHaveLength(1);
+  });
+
+  it('creates audit_entries table', () => {
+    const tables = db.getDB().prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='audit_entries'"
+    ).all();
+    expect(tables).toHaveLength(1);
+  });
+
+  it('close is idempotent', () => {
+    db.close();
+    db.close();
+  });
+});

--- a/packages/core/src/db/database.ts
+++ b/packages/core/src/db/database.ts
@@ -1,0 +1,57 @@
+import Database, { type Database as DatabaseType } from 'better-sqlite3';
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+const DB_FILENAME = 'chainvault.db';
+
+const MIGRATIONS = [
+  `CREATE TABLE IF NOT EXISTS spend_records (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_name TEXT NOT NULL,
+    chain_id INTEGER NOT NULL,
+    amount REAL NOT NULL,
+    timestamp INTEGER NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_spend_agent_chain
+    ON spend_records(agent_name, chain_id, timestamp)`,
+  `CREATE TABLE IF NOT EXISTS audit_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    action TEXT NOT NULL,
+    chain_id INTEGER NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('approved', 'denied')),
+    details TEXT NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_audit_agent ON audit_entries(agent)`,
+  `CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_entries(status)`,
+];
+
+export class ChainVaultDB {
+  private db: DatabaseType;
+
+  constructor(basePath: string) {
+    mkdirSync(basePath, { recursive: true });
+    this.db = new Database(join(basePath, DB_FILENAME));
+    this.db.pragma('journal_mode = WAL');
+    this.runMigrations();
+  }
+
+  private runMigrations(): void {
+    for (const sql of MIGRATIONS) {
+      this.db.exec(sql);
+    }
+  }
+
+  getDB(): DatabaseType {
+    return this.db;
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // already closed
+    }
+  }
+}

--- a/packages/core/src/db/spend-store.test.ts
+++ b/packages/core/src/db/spend-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ChainVaultDB } from './database.js';
+import { SpendStore } from './spend-store.js';
+
+describe('SpendStore', () => {
+  let testDir: string;
+  let db: ChainVaultDB;
+  let store: SpendStore;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'chainvault-spend-'));
+    db = new ChainVaultDB(testDir);
+    store = new SpendStore(db);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('records a spend', () => {
+    store.record('deployer', 11155111, 0.5);
+    const total = store.getSpentSince('deployer', 11155111, 0);
+    expect(total).toBe(0.5);
+  });
+
+  it('accumulates multiple spends', () => {
+    store.record('deployer', 11155111, 0.5);
+    store.record('deployer', 11155111, 0.3);
+    const total = store.getSpentSince('deployer', 11155111, 0);
+    expect(total).toBeCloseTo(0.8);
+  });
+
+  it('filters by agent name', () => {
+    store.record('deployer', 11155111, 1.0);
+    store.record('reader', 11155111, 2.0);
+    expect(store.getSpentSince('deployer', 11155111, 0)).toBe(1.0);
+    expect(store.getSpentSince('reader', 11155111, 0)).toBe(2.0);
+  });
+
+  it('filters by chain id', () => {
+    store.record('deployer', 1, 1.0);
+    store.record('deployer', 11155111, 2.0);
+    expect(store.getSpentSince('deployer', 1, 0)).toBe(1.0);
+    expect(store.getSpentSince('deployer', 11155111, 0)).toBe(2.0);
+  });
+
+  it('filters by timestamp', () => {
+    const now = Date.now();
+    store.record('deployer', 1, 1.0);
+    expect(store.getSpentSince('deployer', 1, now + 100000)).toBe(0);
+  });
+
+  it('returns 0 for no records', () => {
+    expect(store.getSpentSince('nobody', 1, 0)).toBe(0);
+  });
+
+  it('persists across SpendStore instances', () => {
+    store.record('deployer', 1, 1.5);
+    const store2 = new SpendStore(db);
+    expect(store2.getSpentSince('deployer', 1, 0)).toBe(1.5);
+  });
+});

--- a/packages/core/src/db/spend-store.ts
+++ b/packages/core/src/db/spend-store.ts
@@ -1,0 +1,22 @@
+import type { ChainVaultDB } from './database.js';
+
+export class SpendStore {
+  private db: ChainVaultDB;
+
+  constructor(db: ChainVaultDB) {
+    this.db = db;
+  }
+
+  record(agentName: string, chainId: number, amount: number): void {
+    this.db.getDB().prepare(
+      'INSERT INTO spend_records (agent_name, chain_id, amount, timestamp) VALUES (?, ?, ?, ?)'
+    ).run(agentName, chainId, amount, Date.now());
+  }
+
+  getSpentSince(agentName: string, chainId: number, since: number): number {
+    const result = this.db.getDB().prepare(
+      'SELECT COALESCE(SUM(amount), 0) as total FROM spend_records WHERE agent_name = ? AND chain_id = ? AND timestamp > ?'
+    ).get(agentName, chainId, since) as { total: number };
+    return result.total;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,12 @@ export { ApiProxy } from './proxy/api-proxy.js';
 // Audit
 export { AuditLogger } from './audit/logger.js';
 
+// Database
+export { ChainVaultDB } from './db/database.js';
+export { SpendStore } from './db/spend-store.js';
+export { AuditStore } from './db/audit-store.js';
+export type { AuditEntry } from './db/audit-store.js';
+
 // MCP
 export { ChainVaultServer } from './mcp/server.js';
 

--- a/packages/core/src/rules/engine.test.ts
+++ b/packages/core/src/rules/engine.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ChainVaultDB } from '../db/database.js';
+import { SpendStore } from '../db/spend-store.js';
 import { RulesEngine, type TxRequest, type ApiRequest } from './engine.js';
 import type { AgentConfig } from '../vault/types.js';
 
@@ -185,5 +190,47 @@ describe('RulesEngine', () => {
       });
       expect(result.approved).toBe(true);
     });
+  });
+});
+
+describe('RulesEngine with SpendStore', () => {
+  let testDir: string;
+  let db: ChainVaultDB;
+  let spendStore: SpendStore;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'chainvault-rules-db-'));
+    db = new ChainVaultDB(testDir);
+    spendStore = new SpendStore(db);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('uses SpendStore for persistent spend tracking', () => {
+    const engine = new RulesEngine(DEPLOYER_CONFIG, { spendStore, agentName: 'deployer' });
+    engine.recordSpend(11155111, 4.5);
+
+    const engine2 = new RulesEngine(DEPLOYER_CONFIG, { spendStore, agentName: 'deployer' });
+    const result = engine2.checkTxRequest({
+      type: 'write',
+      chain_id: 11155111,
+      value: '1.0',
+    });
+    expect(result.approved).toBe(false);
+    expect(result.reason).toContain('daily limit');
+  });
+
+  it('falls back to in-memory when no SpendStore provided', () => {
+    const engine = new RulesEngine(DEPLOYER_CONFIG);
+    engine.recordSpend(11155111, 4.5);
+    const result = engine.checkTxRequest({
+      type: 'write',
+      chain_id: 11155111,
+      value: '1.0',
+    });
+    expect(result.approved).toBe(false);
   });
 });

--- a/packages/core/src/rules/engine.ts
+++ b/packages/core/src/rules/engine.ts
@@ -1,4 +1,10 @@
 import type { AgentConfig } from '../vault/types.js';
+import type { SpendStore } from '../db/spend-store.js';
+
+interface RulesEngineOptions {
+  spendStore?: SpendStore;
+  agentName?: string;
+}
 
 export interface TxRequest {
   type: 'deploy' | 'write' | 'transfer' | 'read' | 'simulate';
@@ -25,9 +31,13 @@ interface SpendRecord {
 export class RulesEngine {
   private config: AgentConfig;
   private spendHistory: Map<number, SpendRecord[]> = new Map(); // chain_id -> records
+  private spendStore: SpendStore | null;
+  private agentName: string;
 
-  constructor(config: AgentConfig) {
+  constructor(config: AgentConfig, options?: RulesEngineOptions) {
     this.config = config;
+    this.spendStore = options?.spendStore ?? null;
+    this.agentName = options?.agentName ?? config.name;
   }
 
   checkTxRequest(request: TxRequest): RuleResult {
@@ -71,9 +81,13 @@ export class RulesEngine {
   }
 
   recordSpend(chainId: number, amount: number): void {
-    const records = this.spendHistory.get(chainId) || [];
-    records.push({ amount, timestamp: Date.now() });
-    this.spendHistory.set(chainId, records);
+    if (this.spendStore) {
+      this.spendStore.record(this.agentName, chainId, amount);
+    } else {
+      const records = this.spendHistory.get(chainId) || [];
+      records.push({ amount, timestamp: Date.now() });
+      this.spendHistory.set(chainId, records);
+    }
   }
 
   private checkContractRules(address: string): RuleResult {
@@ -140,6 +154,9 @@ export class RulesEngine {
   }
 
   private getSpentSince(chainId: number, since: number): number {
+    if (this.spendStore) {
+      return this.spendStore.getSpentSince(this.agentName, chainId, since);
+    }
     const records = this.spendHistory.get(chainId) || [];
     return records
       .filter((r) => r.timestamp >= since)


### PR DESCRIPTION
## Summary

- **SQLite database layer**: Persistent spend tracking (`SpendStore`) and audit logging (`AuditStore`) backed by `better-sqlite3`, replacing in-memory spend tracking that was lost on server restart
- **Interactive TUI**: 6-screen terminal UI built with Ink/React — Dashboard, Keys, Agents, Services, Logs, Rules — with main-menu navigation, masked password prompt, and 15-minute auto-lock
- **RulesEngine integration**: Optional `SpendStore` parameter for persistent daily/monthly spend limits, with backward-compatible in-memory fallback
- `chainvault` (no args) now launches the TUI; subcommands (`init`, `serve`, etc.) still work as before

## Test plan

- [x] All 104 unit + integration tests passing (`npx vitest run`)
- [x] TypeScript strict mode clean (`npx tsc --noEmit`)
- [x] Full build passes (`npm run build`)
- [ ] Manual: `node packages/cli/dist/index.js` shows password prompt → main menu → all 6 screens navigable
- [ ] Manual: Auto-lock triggers after 15 min inactivity
- [ ] Manual: Spend tracking persists across server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)