### PR TITLE
feat: comprehensive e2e testing — TUI, MCP, chain registry, Claude SDK

### DIFF
--- a/docs/plans/2026-03-20-comprehensive-e2e-implementation.md
+++ b/docs/plans/2026-03-20-comprehensive-e2e-implementation.md
@@ -1,0 +1,1298 @@
+# Comprehensive E2E Testing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add 185+ end-to-end tests covering every TUI screen flow, MCP server integration, and Claude SDK agent-driven tool usage.
+
+**Architecture:** TUI tests use `ink-testing-library` to render Ink components and simulate keystrokes against real vault operations in temp directories. MCP tests use `@modelcontextprotocol/sdk` Client with in-process transport. Claude SDK scripts use `@anthropic-ai/claude-code` to drive the MCP server with a real AI agent.
+
+**Tech Stack:** `ink-testing-library`, `vitest`, `@modelcontextprotocol/sdk`, `@anthropic-ai/claude-code`, real vault operations on temp dirs.
+
+**Design Doc:** `docs/plans/2026-03-20-comprehensive-e2e-testing-design.md`
+
+---
+
+## Task 1: Install Dependencies & Test Helpers
+
+**Files:**
+- Modify: `packages/cli/package.json`
+- Modify: `package.json` (root)
+- Create: `packages/cli/src/tui/test-helpers.ts`
+- Modify: `vitest.config.ts`
+
+**Step 1: Add ink-testing-library to CLI package**
+
+```bash
+cd packages/cli && npm install --save-dev ink-testing-library@4.0.0
+```
+
+**Step 2: Add Claude SDK to root**
+
+```bash
+npm install --save-dev @anthropic-ai/claude-code
+```
+
+**Step 3: Create test helpers for TUI tests**
+
+```typescript
+// packages/cli/src/tui/test-helpers.ts
+import React from 'react';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MasterVault, AgentVaultManager, ChainVaultDB, AuditStore } from '@chainvault/core';
+
+// Ink special key escape sequences
+export const KEYS = {
+  UP: '\x1B[A',
+  DOWN: '\x1B[B',
+  ENTER: '\r',
+  ESCAPE: '\x1B',
+  BACKSPACE: '\x7F',
+  TAB: '\t',
+} as const;
+
+export function type(stdin: { write: (s: string) => void }, text: string) {
+  for (const char of text) {
+    stdin.write(char);
+  }
+}
+
+export function press(stdin: { write: (s: string) => void }, key: keyof typeof KEYS) {
+  stdin.write(KEYS[key]);
+}
+
+const TEST_PASSWORD = 'test-password-123';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+export { TEST_PASSWORD, TEST_PRIVATE_KEY };
+
+export async function createTestVault(): Promise<{
+  dir: string;
+  vault: MasterVault;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'cv-tui-test-'));
+  await MasterVault.init(dir, TEST_PASSWORD);
+  const vault = await MasterVault.unlock(dir, TEST_PASSWORD);
+  return {
+    dir,
+    vault,
+    cleanup: async () => {
+      vault.lock();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createTestVaultWithData(): Promise<{
+  dir: string;
+  vault: MasterVault;
+  manager: AgentVaultManager;
+  cleanup: () => Promise<void>;
+}> {
+  const { dir, vault, cleanup } = await createTestVault();
+  await vault.addKey('test-wallet', TEST_PRIVATE_KEY, [1, 11155111]);
+  await vault.addApiKey('etherscan', 'TEST_KEY', 'https://api.etherscan.io');
+  await vault.addRpcEndpoint('sepolia', 'https://rpc.sepolia.org', 11155111);
+  const manager = new AgentVaultManager(dir, vault);
+  return { dir, vault, manager, cleanup };
+}
+
+export function createTestAuditStore(dir: string): AuditStore {
+  const db = new ChainVaultDB(dir);
+  return new AuditStore(db);
+}
+
+// Wait for async renders to settle
+export async function waitForRender(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+```
+
+**Step 4: Update vitest config to include .tsx test files**
+
+The current vitest config already includes `packages/*/src/**/*.test.ts`. TSX test files need the `.test.tsx` extension to be included. Update the glob:
+
+In `vitest.config.ts`, change:
+```typescript
+include: ['packages/*/src/**/*.test.ts'],
+```
+to:
+```typescript
+include: ['packages/*/src/**/*.test.{ts,tsx}'],
+```
+
+Also add the coverage exclude:
+```typescript
+exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
+```
+
+**Step 5: Verify setup**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+**Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "chore: add ink-testing-library, claude-code SDK, and TUI test helpers"
+```
+
+---
+
+## Task 2: PasswordPrompt E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx`
+
+**Step 1: Write the tests**
+
+```tsx
+// packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { PasswordPrompt } from './PasswordPrompt.js';
+import { KEYS, type, press, waitForRender } from '../test-helpers.js';
+
+describe('PasswordPrompt E2E', () => {
+  describe('dual-prompt mode (hasPasskey=true)', () => {
+    it('renders passkey and password options', () => {
+      const { lastFrame } = render(
+        <PasswordPrompt onSubmit={vi.fn()} hasPasskey={true} onPasskeyRequest={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('[P] Passkey');
+      expect(lastFrame()).toContain('[T] Type password');
+    });
+
+    it('P key triggers onPasskeyRequest', () => {
+      const onPasskey = vi.fn();
+      const { stdin } = render(
+        <PasswordPrompt onSubmit={vi.fn()} hasPasskey={true} onPasskeyRequest={onPasskey} />,
+      );
+      stdin.write('P');
+      expect(onPasskey).toHaveBeenCalledOnce();
+    });
+
+    it('p key (lowercase) also triggers onPasskeyRequest', () => {
+      const onPasskey = vi.fn();
+      const { stdin } = render(
+        <PasswordPrompt onSubmit={vi.fn()} hasPasskey={true} onPasskeyRequest={onPasskey} />,
+      );
+      stdin.write('p');
+      expect(onPasskey).toHaveBeenCalledOnce();
+    });
+
+    it('T key switches to password mode', () => {
+      const { stdin, lastFrame } = render(
+        <PasswordPrompt onSubmit={vi.fn()} hasPasskey={true} onPasskeyRequest={vi.fn()} />,
+      );
+      stdin.write('T');
+      expect(lastFrame()).toContain('Enter master vault password');
+      expect(lastFrame()).not.toContain('[P] Passkey');
+    });
+
+    it('t key (lowercase) also switches to password mode', () => {
+      const { stdin, lastFrame } = render(
+        <PasswordPrompt onSubmit={vi.fn()} hasPasskey={true} onPasskeyRequest={vi.fn()} />,
+      );
+      stdin.write('t');
+      expect(lastFrame()).toContain('Enter master vault password');
+    });
+  });
+
+  describe('password-only mode (hasPasskey=false)', () => {
+    it('renders password prompt directly', () => {
+      const { lastFrame } = render(<PasswordPrompt onSubmit={vi.fn()} />);
+      expect(lastFrame()).toContain('Enter master vault password');
+    });
+
+    it('typing renders asterisks', () => {
+      const { stdin, lastFrame } = render(<PasswordPrompt onSubmit={vi.fn()} />);
+      stdin.write('a');
+      stdin.write('b');
+      stdin.write('c');
+      expect(lastFrame()).toContain('***');
+    });
+
+    it('backspace removes last character', () => {
+      const { stdin, lastFrame } = render(<PasswordPrompt onSubmit={vi.fn()} />);
+      stdin.write('a');
+      stdin.write('b');
+      stdin.write('c');
+      stdin.write(KEYS.BACKSPACE);
+      expect(lastFrame()).toContain('**');
+      expect(lastFrame()).not.toContain('***');
+    });
+
+    it('Enter with empty password shows validation error', () => {
+      const onSubmit = vi.fn();
+      const { stdin, lastFrame } = render(<PasswordPrompt onSubmit={onSubmit} />);
+      stdin.write(KEYS.ENTER);
+      expect(lastFrame()).toContain('Password cannot be empty');
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Enter with password calls onSubmit', () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(<PasswordPrompt onSubmit={onSubmit} />);
+      type(stdin, 'mypassword');
+      stdin.write(KEYS.ENTER);
+      expect(onSubmit).toHaveBeenCalledWith('mypassword');
+    });
+
+    it('displays error prop', () => {
+      const { lastFrame } = render(
+        <PasswordPrompt onSubmit={vi.fn()} error="Wrong password" />,
+      );
+      expect(lastFrame()).toContain('Wrong password');
+    });
+
+    it('typing clears validation error', () => {
+      const { stdin, lastFrame } = render(<PasswordPrompt onSubmit={vi.fn()} />);
+      stdin.write(KEYS.ENTER); // trigger validation error
+      expect(lastFrame()).toContain('Password cannot be empty');
+      stdin.write('a');
+      expect(lastFrame()).not.toContain('Password cannot be empty');
+    });
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx`
+Expected: All 10 tests PASS.
+
+**Step 3: Fix any failures, then commit**
+
+```bash
+git add packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx
+git commit -m "test(tui): add PasswordPrompt e2e tests with ink-testing-library"
+```
+
+---
+
+## Task 3: MainMenu E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/components/MainMenu.e2e.test.tsx`
+
+**Step 1: Write the tests**
+
+```tsx
+// packages/cli/src/tui/components/MainMenu.e2e.test.tsx
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { MainMenu } from './MainMenu.js';
+import { KEYS } from '../test-helpers.js';
+
+describe('MainMenu E2E', () => {
+  it('renders all 6 menu items', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={3} agentCount={2} onSelect={vi.fn()} />,
+    );
+    expect(lastFrame()).toContain('Dashboard');
+    expect(lastFrame()).toContain('Keys');
+    expect(lastFrame()).toContain('Agents');
+    expect(lastFrame()).toContain('Services');
+    expect(lastFrame()).toContain('Logs');
+    expect(lastFrame()).toContain('Rules');
+  });
+
+  it('shows key and agent counts in header', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={5} agentCount={3} onSelect={vi.fn()} />,
+    );
+    expect(lastFrame()).toContain('5 keys');
+    expect(lastFrame()).toContain('3 agents');
+  });
+
+  it('first item is selected by default', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    expect(lastFrame()).toContain('> Dashboard');
+  });
+
+  it('down arrow moves selection down', () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    stdin.write(KEYS.DOWN);
+    expect(lastFrame()).toContain('> Keys');
+  });
+
+  it('up arrow wraps from top to bottom', () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    stdin.write(KEYS.UP);
+    expect(lastFrame()).toContain('> Rules');
+  });
+
+  it('down arrow wraps from bottom to top', () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    for (let i = 0; i < 6; i++) stdin.write(KEYS.DOWN);
+    expect(lastFrame()).toContain('> Dashboard');
+  });
+
+  it('Enter on Dashboard calls onSelect with dashboard', () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+    );
+    stdin.write(KEYS.ENTER);
+    expect(onSelect).toHaveBeenCalledWith('dashboard');
+  });
+
+  it('navigate to Keys and select', () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+    );
+    stdin.write(KEYS.DOWN);
+    stdin.write(KEYS.ENTER);
+    expect(onSelect).toHaveBeenCalledWith('keys');
+  });
+
+  it('navigate to each screen and select', () => {
+    const screens = ['dashboard', 'keys', 'agents', 'services', 'logs', 'rules'];
+    for (let i = 0; i < screens.length; i++) {
+      const onSelect = vi.fn();
+      const { stdin } = render(
+        <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+      );
+      for (let j = 0; j < i; j++) stdin.write(KEYS.DOWN);
+      stdin.write(KEYS.ENTER);
+      expect(onSelect).toHaveBeenCalledWith(screens[i]);
+    }
+  });
+
+  it('shows navigation help text', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    expect(lastFrame()).toContain('arrows navigate');
+    expect(lastFrame()).toContain('Enter select');
+  });
+});
+```
+
+**Step 2: Run and commit**
+
+Run: `npx vitest run packages/cli/src/tui/components/MainMenu.e2e.test.tsx`
+Commit: `test(tui): add MainMenu e2e tests`
+
+---
+
+## Task 4: KeysScreen E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx`
+
+**Step 1: Write the tests**
+
+```tsx
+// packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { KeysScreen } from './KeysScreen.js';
+import { KEYS, type, press, createTestVault, waitForRender, TEST_PRIVATE_KEY } from '../test-helpers.js';
+
+const MOCK_KEYS = [
+  { name: 'wallet-1', address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', chains: [1, 11155111] },
+  { name: 'wallet-2', address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', chains: [137] },
+];
+
+describe('KeysScreen E2E', () => {
+  describe('list mode', () => {
+    it('renders all keys with addresses and chains', () => {
+      const { lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('wallet-1');
+      expect(lastFrame()).toContain('0xf39F');
+      expect(lastFrame()).toContain('wallet-2');
+    });
+
+    it('shows empty state when no keys', () => {
+      const { lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('Keys');
+    });
+
+    it('arrow navigation highlights different keys', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('> wallet-1');
+      stdin.write(KEYS.DOWN);
+      expect(lastFrame()).toContain('> wallet-2');
+    });
+
+    it('Esc calls onBack', () => {
+      const onBack = vi.fn();
+      const { stdin } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={onBack} />,
+      );
+      stdin.write(KEYS.ESCAPE);
+      expect(onBack).toHaveBeenCalledOnce();
+    });
+
+    it('shows help text with available actions', () => {
+      const { lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      expect(lastFrame()).toContain('a add');
+      expect(lastFrame()).toContain('d delete');
+    });
+  });
+
+  describe('add flow', () => {
+    it('a key enters add-name mode', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      expect(lastFrame()).toContain('Key name');
+    });
+
+    it('empty name shows validation error', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      stdin.write(KEYS.ENTER);
+      expect(lastFrame()).toContain('empty');
+    });
+
+    it('valid name proceeds to private key prompt', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      expect(lastFrame()).toContain('Private key');
+    });
+
+    it('empty private key shows validation error', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      stdin.write(KEYS.ENTER); // empty key
+      expect(lastFrame()).toContain('empty');
+    });
+
+    it('private key shown as asterisks', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      type(stdin, '0xabc');
+      expect(lastFrame()).toContain('*****');
+      expect(lastFrame()).not.toContain('0xabc');
+    });
+
+    it('valid key proceeds to chain IDs prompt', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      type(stdin, '0xabc123');
+      stdin.write(KEYS.ENTER);
+      expect(lastFrame()).toContain('Chain IDs');
+    });
+
+    it('invalid chain IDs show error', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      type(stdin, '0xabc');
+      stdin.write(KEYS.ENTER);
+      type(stdin, 'invalid');
+      stdin.write(KEYS.ENTER);
+      expect(lastFrame()).toContain('invalid') || expect(lastFrame()).toContain('error');
+    });
+
+    it('complete add flow calls onAddKey with correct args', async () => {
+      const onAddKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <KeysScreen keys={[]} onAddKey={onAddKey} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ENTER);
+      type(stdin, TEST_PRIVATE_KEY);
+      stdin.write(KEYS.ENTER);
+      type(stdin, '1,11155111');
+      stdin.write(KEYS.ENTER);
+      await waitForRender();
+      expect(onAddKey).toHaveBeenCalledWith('my-key', TEST_PRIVATE_KEY, [1, 11155111]);
+    });
+
+    it('Esc during add returns to list without calling onAddKey', () => {
+      const onAddKey = vi.fn();
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={onAddKey} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'my-key');
+      stdin.write(KEYS.ESCAPE);
+      expect(onAddKey).not.toHaveBeenCalled();
+      expect(lastFrame()).toContain('wallet-1');
+    });
+
+    it('backspace in name field removes character', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={[]} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'abc');
+      stdin.write(KEYS.BACKSPACE);
+      expect(lastFrame()).toContain('ab');
+    });
+  });
+
+  describe('delete flow', () => {
+    it('d key shows delete confirmation', () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('d');
+      expect(lastFrame()).toContain('Delete');
+      expect(lastFrame()).toContain('wallet-1');
+      expect(lastFrame()).toContain('y/n');
+    });
+
+    it('y confirms deletion and calls onRemoveKey', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={onRemoveKey} onBack={vi.fn()} />,
+      );
+      stdin.write('d');
+      stdin.write('y');
+      await waitForRender();
+      expect(onRemoveKey).toHaveBeenCalledWith('wallet-1');
+    });
+
+    it('n cancels deletion', () => {
+      const onRemoveKey = vi.fn();
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={onRemoveKey} onBack={vi.fn()} />,
+      );
+      stdin.write('d');
+      stdin.write('n');
+      expect(onRemoveKey).not.toHaveBeenCalled();
+      expect(lastFrame()).toContain('wallet-1');
+    });
+
+    it('Esc cancels deletion', () => {
+      const onRemoveKey = vi.fn();
+      const { stdin, lastFrame } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={onRemoveKey} onBack={vi.fn()} />,
+      );
+      stdin.write('d');
+      stdin.write(KEYS.ESCAPE);
+      expect(onRemoveKey).not.toHaveBeenCalled();
+    });
+
+    it('navigate to second key then delete it', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <KeysScreen keys={MOCK_KEYS} onAddKey={vi.fn()} onRemoveKey={onRemoveKey} onBack={vi.fn()} />,
+      );
+      stdin.write(KEYS.DOWN); // select wallet-2
+      stdin.write('d');
+      stdin.write('y');
+      await waitForRender();
+      expect(onRemoveKey).toHaveBeenCalledWith('wallet-2');
+    });
+  });
+
+  describe('full roundtrip with real vault', () => {
+    let testDir: string;
+    let vault: any;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await createTestVault();
+      testDir = result.dir;
+      vault = result.vault;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it('adds a key and verifies it persists in vault', async () => {
+      const onAddKey = async (name: string, key: string, chains: number[]) => {
+        await vault.addKey(name, key, chains);
+      };
+      const { stdin } = render(
+        <KeysScreen keys={vault.listKeys()} onAddKey={onAddKey} onRemoveKey={vi.fn()} onBack={vi.fn()} />,
+      );
+      stdin.write('a');
+      type(stdin, 'e2e-key');
+      stdin.write(KEYS.ENTER);
+      type(stdin, TEST_PRIVATE_KEY);
+      stdin.write(KEYS.ENTER);
+      type(stdin, '1');
+      stdin.write(KEYS.ENTER);
+      await waitForRender(100);
+      const keys = vault.listKeys();
+      expect(keys).toHaveLength(1);
+      expect(keys[0].name).toBe('e2e-key');
+    });
+
+    it('removes a key and verifies it is gone from vault', async () => {
+      await vault.addKey('to-remove', TEST_PRIVATE_KEY, [1]);
+      const onRemoveKey = async (name: string) => {
+        await vault.removeKey(name);
+      };
+      const { stdin } = render(
+        <KeysScreen keys={vault.listKeys()} onAddKey={vi.fn()} onRemoveKey={onRemoveKey} onBack={vi.fn()} />,
+      );
+      stdin.write('d');
+      stdin.write('y');
+      await waitForRender(100);
+      expect(vault.listKeys()).toHaveLength(0);
+    });
+  });
+});
+```
+
+**Step 2: Run and fix**
+
+Run: `npx vitest run packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx`
+Fix any failures. Do NOT alter test assertions — fix the source or test setup.
+
+**Step 3: Commit**
+
+```bash
+git add packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx
+git commit -m "test(tui): add KeysScreen e2e tests — add/delete flows with real vault"
+```
+
+---
+
+## Task 5: AgentsScreen E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/AgentsScreen.e2e.test.tsx`
+
+Follow the same pattern as KeysScreen. Test the create flow (name → chains → tx types → vault key display → any key to dismiss), revoke flow (d → confirm), and full roundtrip with real `AgentVaultManager`. Verify vault key format matches `cv_agent_[a-f0-9]{64}`. Verify agent config persists in master vault data. ~25 tests.
+
+Key test cases:
+- List mode renders agents with chains and types
+- `a` enters create-name mode
+- Empty name → error
+- Valid name → create-chains mode
+- Invalid chain IDs → error
+- Valid chains → create-types mode
+- Invalid tx types (e.g., "hack") → error
+- Valid types → creates agent, shows vault key
+- Vault key matches `cv_agent_` format
+- Any key after vault key display → back to list
+- `d` → confirm-revoke → y → agent removed
+- `d` → confirm-revoke → n → agent preserved
+- Esc during creation → back to list without creating
+- Full roundtrip: create agent with real vault → verify `.vault` file exists
+- Full roundtrip: revoke agent → verify file removed
+
+**Step 1: Write tests following KeysScreen pattern**
+**Step 2: Run and fix**
+**Step 3: Commit**
+
+```bash
+git commit -m "test(tui): add AgentsScreen e2e tests — create/revoke flows with real vault"
+```
+
+---
+
+## Task 6: ServicesScreen E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/ServicesScreen.e2e.test.tsx`
+
+Test both API and RPC sections, Tab switching, and add/delete flows for each. ~25 tests.
+
+Key test cases:
+- Renders API keys section with names and URLs
+- Renders RPC endpoints section with names and chain IDs
+- Tab switches active section (visual indication)
+- API add flow: a → name → key (masked) → URL → calls onAddApiKey
+- RPC add flow: Tab → a → name → URL → chain ID → calls onAddRpcEndpoint
+- API delete: d → confirm y → calls onRemoveApiKey
+- RPC delete: Tab → d → confirm y → calls onRemoveRpcEndpoint
+- API key value never appears in rendered output (masked)
+- Empty name → error in both sections
+- Invalid chain ID for RPC → error
+- Esc during add → back to list
+- Full roundtrip: add API key + RPC with real vault → verify persists
+
+**Step 1-3: Write, run, commit**
+
+```bash
+git commit -m "test(tui): add ServicesScreen e2e tests — API/RPC add/delete with Tab switching"
+```
+
+---
+
+## Task 7: LogsScreen E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/LogsScreen.e2e.test.tsx`
+
+Test filtering, scrolling, and display. ~20 tests.
+
+Key test cases:
+- Renders audit entries with timestamps
+- Shows green `+` for approved entries
+- Shows red `x` for denied entries
+- `f` cycles filter: all → approved → denied → all
+- Filtered view shows only matching entries
+- Arrow down scrolls the log
+- Arrow up scrolls back
+- Shows correct page count (entries / 15)
+- Empty log shows "No log entries" or similar
+- Full roundtrip: create AuditStore → add 20 mixed entries → verify display → filter approved → verify only approved shown → filter denied → verify
+
+**Step 1-3: Write, run, commit**
+
+```bash
+git commit -m "test(tui): add LogsScreen e2e tests — filter cycling, scroll, pagination"
+```
+
+---
+
+## Task 8: RulesScreen E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/RulesScreen.e2e.test.tsx`
+
+Test agent selection, edit menu navigation, and all three edit flows (chains, types, limits). ~25 tests.
+
+Key test cases:
+- Lists agents for selection
+- Enter selects agent → shows edit menu
+- Edit menu has 4 options (Chains, Types, Limits, Back)
+- Navigate edit menu with arrows
+- Edit Chains: enter valid chain IDs → updates vault → success message
+- Edit Chains: invalid IDs → error, vault unchanged
+- Edit Tx Types: valid types → updates vault → success
+- Edit Tx Types: invalid type → error
+- Edit Limits: valid format `1:0.5:5.0:50.0` → updates vault → success
+- Edit Limits: malformed format → error
+- Back from edit menu → agent selection
+- Esc from agent selection → onBack
+- Full roundtrip with real vault: create agent → edit chains to [1,137] → verify in vault.getData() → edit types → verify → edit limits → verify
+
+**Step 1-3: Write, run, commit**
+
+```bash
+git commit -m "test(tui): add RulesScreen e2e tests — edit chains/types/limits with real vault"
+```
+
+---
+
+## Task 9: Dashboard & App E2E Tests
+
+**Files:**
+- Create: `packages/cli/src/tui/screens/Dashboard.e2e.test.tsx`
+- Create: `packages/cli/src/tui/App.e2e.test.tsx`
+
+### Dashboard (~10 tests):
+- Displays vault path
+- Shows key/agent/RPC counts
+- Shows "unlocked" status
+- Shows recent activity entries
+- Esc calls onBack
+- Shows help text with [R] Register passkey
+
+### App full journey (~20 tests):
+- Renders password prompt when no vault is unlocked
+- Wrong password shows error
+- Correct password shows main menu
+- Navigate to Keys screen → verify renders
+- Navigate to each screen → verify renders correctly
+- Esc from screen → back to menu
+- Add key via Keys screen → verify count updates in menu
+- Full journey: unlock → Keys → add key → back → Agents → create agent → back → verify counts
+
+**Step 1-3: Write, run, commit per file**
+
+```bash
+git commit -m "test(tui): add Dashboard e2e tests"
+git commit -m "test(tui): add App full-journey e2e tests with real vault operations"
+```
+
+---
+
+## Task 10: MCP Server Integration Tests
+
+**Files:**
+- Create: `packages/core/src/mcp/mcp-integration.e2e.test.ts`
+
+**Step 1: Write the MCP integration tests**
+
+```typescript
+// packages/core/src/mcp/mcp-integration.e2e.test.ts
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ChainVaultServer } from './server.js';
+
+describe('MCP Server Integration', { timeout: 30_000 }, () => {
+  async function createConnectedClient() {
+    const server = new ChainVaultServer({ basePath: '/tmp/mcp-test' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.getMcpServer().connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    await client.connect(clientTransport);
+    return { client, server };
+  }
+
+  describe('tool discovery', () => {
+    it('lists all 19 registered tools', async () => {
+      const { client } = await createConnectedClient();
+      const { tools } = await client.listTools();
+      expect(tools.length).toBe(19);
+    });
+
+    it('every tool has a name, description, and inputSchema', async () => {
+      const { client } = await createConnectedClient();
+      const { tools } = await client.listTools();
+      for (const tool of tools) {
+        expect(tool.name).toBeDefined();
+        expect(tool.description).toBeDefined();
+        expect(tool.inputSchema).toBeDefined();
+      }
+    });
+
+    it('includes expected tool names', async () => {
+      const { client } = await createConnectedClient();
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('list_supported_chains');
+      expect(names).toContain('request_faucet');
+      expect(names).toContain('compile_contract');
+      expect(names).toContain('deploy_contract');
+      expect(names).toContain('get_balance');
+    });
+  });
+
+  describe('list_supported_chains', () => {
+    it('returns all chains with no filter', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({ name: 'list_supported_chains', arguments: {} });
+      const chains = JSON.parse((result.content as any)[0].text);
+      expect(chains.length).toBeGreaterThanOrEqual(14);
+    });
+
+    it('filters by mainnet', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'mainnet' },
+      });
+      const chains = JSON.parse((result.content as any)[0].text);
+      for (const chain of chains) {
+        expect(chain.network).toBe('mainnet');
+      }
+    });
+
+    it('filters by testnet', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'testnet' },
+      });
+      const chains = JSON.parse((result.content as any)[0].text);
+      expect(chains.length).toBeGreaterThan(0);
+      for (const chain of chains) {
+        expect(chain.network).toBe('testnet');
+      }
+    });
+
+    it('each chain has required fields', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({ name: 'list_supported_chains', arguments: {} });
+      const chains = JSON.parse((result.content as any)[0].text);
+      for (const chain of chains) {
+        expect(chain.chainId).toBeDefined();
+        expect(chain.name).toBeDefined();
+        expect(chain.nativeCurrency).toBeDefined();
+        expect(typeof chain.hasWebSocket).toBe('boolean');
+        expect(typeof chain.hasFaucet).toBe('boolean');
+      }
+    });
+  });
+
+  describe('request_faucet', () => {
+    it('returns result for testnet chain', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 11155111, address: '0x0000000000000000000000000000000000000001' },
+      });
+      const data = JSON.parse((result.content as any)[0].text);
+      expect(data.chainId).toBe(11155111);
+      expect(data.chainName).toBe('Sepolia');
+    });
+
+    it('rejects mainnet chain', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 1, address: '0x0000000000000000000000000000000000000001' },
+      });
+      const data = JSON.parse((result.content as any)[0].text);
+      expect(data.success).toBe(false);
+      expect(data.message).toContain('mainnet');
+    });
+
+    it('rejects unknown chain', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 999999, address: '0x0000000000000000000000000000000000000001' },
+      });
+      const data = JSON.parse((result.content as any)[0].text);
+      expect(data.success).toBe(false);
+    });
+  });
+
+  describe('stub tools respond without error', () => {
+    it('get_balance returns empty response', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'get_balance',
+        arguments: { chain_id: 1, address: '0x0000000000000000000000000000000000000001' },
+      });
+      expect(result.content).toBeDefined();
+    });
+
+    it('list_chains returns empty response', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'list_chains',
+        arguments: {},
+      });
+      expect(result.content).toBeDefined();
+    });
+
+    it('simulate_transaction returns empty response', async () => {
+      const { client } = await createConnectedClient();
+      const result = await client.callTool({
+        name: 'simulate_transaction',
+        arguments: {
+          chain_id: 1,
+          address: '0x0000000000000000000000000000000000000001',
+          abi: '[]',
+          function_name: 'test',
+        },
+      });
+      expect(result.content).toBeDefined();
+    });
+  });
+});
+```
+
+**Step 2: Run tests**
+
+Run: `npx vitest run packages/core/src/mcp/mcp-integration.e2e.test.ts`
+Fix any import/transport issues — the `InMemoryTransport` import path may vary by SDK version.
+
+**Step 3: Commit**
+
+```bash
+git add packages/core/src/mcp/mcp-integration.e2e.test.ts
+git commit -m "test(mcp): add MCP server integration tests — tool discovery, chain registry, faucet"
+```
+
+---
+
+## Task 11: Claude SDK Agent Scripts
+
+**Files:**
+- Create: `tests/agent-e2e/compile-token.ts`
+- Create: `tests/agent-e2e/chain-discovery.ts`
+- Create: `tests/agent-e2e/HelloToken.sol`
+
+**Step 1: Create HelloToken.sol**
+
+```solidity
+// tests/agent-e2e/HelloToken.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract HelloToken {
+    string public name = "HelloToken";
+    string public symbol = "HELLO";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(uint256 _supply) {
+        totalSupply = _supply * 10 ** decimals;
+        balanceOf[msg.sender] = totalSupply;
+        emit Transfer(address(0), msg.sender, totalSupply);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        require(allowance[from][msg.sender] >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}
+```
+
+**Step 2: Create compile-token.ts**
+
+```typescript
+// tests/agent-e2e/compile-token.ts
+import { query } from '@anthropic-ai/claude-code';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  // Check prerequisites
+  if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
+    console.log('SKIP: Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to run this test');
+    process.exit(0);
+  }
+
+  const source = readFileSync(join(__dirname, 'HelloToken.sol'), 'utf-8');
+
+  console.log('Starting Claude SDK compile-token test...');
+  console.log('Sending prompt to compile HelloToken via ChainVault MCP...\n');
+
+  const messages = await query({
+    prompt: `You have access to a compile_contract tool. Use it to compile this Solidity contract.
+Contract name: HelloToken
+Compiler version: 0.8.20
+
+Source code:
+\`\`\`solidity
+${source}
+\`\`\`
+
+Call compile_contract with the source_code, contract_name "HelloToken", and compiler_version "0.8.20". Report the resulting ABI function names and whether bytecode was generated.`,
+    options: {
+      maxTurns: 5,
+      systemPrompt: 'You are a blockchain developer assistant. Use the available MCP tools.',
+      allowedTools: ['mcp__chainvault__compile_contract'],
+      mcpServers: {
+        chainvault: {
+          command: 'node',
+          args: [join(__dirname, '../../packages/cli/dist/index.js'), 'serve'],
+        },
+      },
+      permissionMode: 'acceptEdits',
+    },
+  });
+
+  // Analyze results
+  let toolUsed = false;
+  let responseText = '';
+
+  for (const msg of messages) {
+    if (msg.type === 'result') {
+      responseText += msg.result || '';
+    }
+    // Check if compile_contract was invoked
+    if (msg.type === 'tool_use' || (msg as any).name === 'mcp__chainvault__compile_contract') {
+      toolUsed = true;
+    }
+  }
+
+  console.log('Response:', responseText.slice(0, 500));
+  console.log('\nResults:');
+  console.log('  Tool used (compile_contract):', toolUsed);
+  console.log('  Response mentions ABI:', responseText.includes('abi') || responseText.includes('ABI'));
+  console.log('  Response mentions transfer:', responseText.toLowerCase().includes('transfer'));
+  console.log('  Response mentions bytecode:', responseText.toLowerCase().includes('bytecode'));
+
+  if (!toolUsed) {
+    console.error('\nFAIL: Claude did not use the compile_contract tool');
+    process.exit(1);
+  }
+
+  console.log('\nPASS: Claude successfully used compile_contract via MCP');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});
+```
+
+**Step 3: Create chain-discovery.ts**
+
+```typescript
+// tests/agent-e2e/chain-discovery.ts
+import { query } from '@anthropic-ai/claude-code';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
+    console.log('SKIP: Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to run this test');
+    process.exit(0);
+  }
+
+  console.log('Starting Claude SDK chain-discovery test...');
+  console.log('Asking Claude to discover supported chains and faucets...\n');
+
+  const messages = await query({
+    prompt: 'What testnet blockchains are supported? Which ones have faucets? Use the list_supported_chains tool to find out, then summarize.',
+    options: {
+      maxTurns: 5,
+      systemPrompt: 'You are a blockchain assistant. Use the available MCP tools to answer questions.',
+      allowedTools: ['mcp__chainvault__list_supported_chains', 'mcp__chainvault__request_faucet'],
+      mcpServers: {
+        chainvault: {
+          command: 'node',
+          args: [join(__dirname, '../../packages/cli/dist/index.js'), 'serve'],
+        },
+      },
+      permissionMode: 'acceptEdits',
+    },
+  });
+
+  let responseText = '';
+  let toolUsed = false;
+
+  for (const msg of messages) {
+    if (msg.type === 'result') {
+      responseText += msg.result || '';
+    }
+    if ((msg as any).name === 'mcp__chainvault__list_supported_chains') {
+      toolUsed = true;
+    }
+  }
+
+  console.log('Response:', responseText.slice(0, 800));
+  console.log('\nResults:');
+  console.log('  Tool used (list_supported_chains):', toolUsed);
+  console.log('  Mentions Sepolia:', responseText.includes('Sepolia'));
+  console.log('  Mentions Arbitrum:', responseText.includes('Arbitrum'));
+  console.log('  Mentions faucet:', responseText.toLowerCase().includes('faucet'));
+
+  if (!toolUsed) {
+    console.error('\nFAIL: Claude did not use list_supported_chains');
+    process.exit(1);
+  }
+
+  console.log('\nPASS: Claude discovered chains via MCP');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});
+```
+
+**Step 4: Build and test**
+
+```bash
+npm run build
+npx tsx tests/agent-e2e/chain-discovery.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add tests/agent-e2e/
+git commit -m "test: add Claude SDK agent e2e scripts — compile token and chain discovery"
+```
+
+---
+
+## Task 12: Full Suite Verification
+
+**Step 1: Run all unit + e2e tests**
+
+```bash
+npx vitest run
+```
+
+Expected: All tests pass (243 existing + ~185 new ≈ 428 total).
+
+**Step 2: Type check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: No errors.
+
+**Step 3: Final commit if any fixes needed**
+
+---
+
+## Task Summary
+
+| Task | Scope | Tests | Description |
+|------|-------|-------|-------------|
+| 1 | Setup | 0 | Dependencies, helpers, vitest config |
+| 2 | PasswordPrompt | ~10 | Dual-mode auth, masking, validation |
+| 3 | MainMenu | ~10 | Navigation, selection, counts |
+| 4 | KeysScreen | ~25 | Add/delete flows, real vault roundtrip |
+| 5 | AgentsScreen | ~25 | Create/revoke flows, vault key display |
+| 6 | ServicesScreen | ~25 | API/RPC sections, Tab switching |
+| 7 | LogsScreen | ~20 | Filter cycling, scroll, pagination |
+| 8 | RulesScreen | ~25 | Edit chains/types/limits, real vault |
+| 9 | Dashboard + App | ~30 | Status display, full journey |
+| 10 | MCP Integration | ~20 | Tool discovery, chain registry, faucet |
+| 11 | Claude SDK | 2 scripts | compile-token, chain-discovery |
+| 12 | Verification | 0 | Full suite + type check |
+
+**Total: ~190 new tests + 2 agent scripts**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/cli"
       ],
       "devDependencies": {
+        "@anthropic-ai/claude-code": "^2.1.80",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -37,6 +38,30 @@
       },
       "engines": {
         "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.80",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.80.tgz",
+      "integrity": "sha512-YAgNNr3fzn3xaTNm+CYgebdEinU9D0HxGUT2C1N2Ej2HCvt5AjrSoU8vTgccxx4oPkj1R4gpuZWi1rTKvxNaPQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
       }
     },
     "node_modules/@chainvault/cli": {
@@ -505,6 +530,326 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2616,6 +2961,24 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ink-text-input": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
@@ -4346,7 +4709,8 @@
         "chainvault": "dist/index.js"
       },
       "devDependencies": {
-        "@types/react": "^18.3.0"
+        "@types/react": "^18.3.0",
+        "ink-testing-library": "^4.0.0"
       }
     },
     "packages/core": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "serve": "node packages/cli/dist/index.js serve"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-code": "^2.1.80",
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "react": "^18.3.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0"
+    "@types/react": "^18.3.0",
+    "ink-testing-library": "^4.0.0"
   }
 }

--- a/packages/cli/src/tui/App.e2e.test.tsx
+++ b/packages/cli/src/tui/App.e2e.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { App } from './App.js';
+import {
+  KEYS,
+  type,
+  createTestVault,
+  createTestVaultWithData,
+  TEST_PASSWORD,
+  TEST_PRIVATE_KEY,
+} from './test-helpers.js';
+import { MasterVault } from '@chainvault/core';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+describe('App e2e', () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const result = await createTestVault();
+    testDir = result.dir;
+    // Lock the vault so App starts in locked state
+    result.vault.lock();
+    cleanup = result.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── Password Prompt ────────────────────────────────────
+
+  describe('password prompt', () => {
+    it('renders password prompt when vault is locked', async () => {
+      const { lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      const frame = lastFrame()!;
+      expect(frame).toContain('password');
+    });
+
+    it('shows "ChainVault" title on password prompt', async () => {
+      const { lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      expect(lastFrame()!).toContain('ChainVault');
+    });
+
+    it('wrong password shows error message', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      type(stdin, 'wrong-password');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+      expect(lastFrame()!).toContain('Wrong password');
+    });
+
+    it('correct password unlocks and shows main menu', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      type(stdin, TEST_PASSWORD);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Dashboard');
+      expect(frame).toContain('Keys');
+      expect(frame).toContain('Agents');
+    });
+  });
+
+  // ── Main Menu ──────────────────────────────────────────
+
+  describe('main menu', () => {
+    async function unlockApp(stdin: { write: (s: string) => void }) {
+      await delay();
+      type(stdin, TEST_PASSWORD);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+    }
+
+    it('shows all 6 screen options after unlock', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Dashboard');
+      expect(frame).toContain('Keys');
+      expect(frame).toContain('Agents');
+      expect(frame).toContain('Services');
+      expect(frame).toContain('Logs');
+      expect(frame).toContain('Rules');
+    });
+
+    it('navigate to Dashboard (Enter on first item) shows "unlocked" and vault path', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Dashboard is the first item, Enter selects it
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      const frame = lastFrame()!;
+      expect(frame).toContain('unlocked');
+      expect(frame).toContain(testDir);
+    });
+
+    it('navigate to Keys (down + Enter) shows Keys screen', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Move down to Keys (second item)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      const frame = lastFrame()!;
+      // KeysScreen shows "No keys stored" when empty
+      expect(frame).toContain('No keys stored');
+    });
+
+    it('Esc from Dashboard returns to main menu', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Go to Dashboard
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      expect(lastFrame()!).toContain('unlocked');
+      // Press Esc to go back
+      stdin.write(KEYS.ESCAPE);
+      await delay(300);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Dashboard');
+      expect(frame).toContain('Keys');
+      expect(frame).toContain('Agents');
+    });
+
+    it('Esc from Keys returns to main menu', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Go to Keys
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      expect(lastFrame()!).toContain('No keys stored');
+      // Press Esc to go back
+      stdin.write(KEYS.ESCAPE);
+      await delay(300);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Dashboard');
+      expect(frame).toContain('Keys');
+    });
+
+    it('navigate to Services shows Services screen', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Move down to Services (4th item: Dashboard, Keys, Agents, Services)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      const frame = lastFrame()!;
+      // ServicesScreen should show API keys / RPC endpoints sections
+      expect(frame).toContain('API');
+    });
+
+    it('navigate to Logs shows Logs screen', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await unlockApp(stdin);
+      // Move down to Logs (5th item)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Audit Logs');
+    });
+  });
+
+  // ── Real vault data roundtrip ──────────────────────────
+
+  describe('vault data roundtrip', () => {
+    it('Dashboard shows correct key count after adding key via Keys screen', async () => {
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      // Unlock
+      await delay();
+      type(stdin, TEST_PASSWORD);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+
+      // Navigate to Keys screen (second item)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      // Add a key: press 'a', type name, Enter, type key, Enter, type chains, Enter
+      stdin.write('a');
+      await delay();
+      type(stdin, 'e2e-wallet');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, TEST_PRIVATE_KEY);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1,11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      // Go back to main menu
+      stdin.write(KEYS.ESCAPE);
+      await delay(300);
+
+      // Main menu should now show "1 keys"
+      const menuFrame = lastFrame()!;
+      expect(menuFrame).toContain('1 keys');
+
+      // Navigate to Dashboard (first item)
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      // Dashboard should show key count of 1
+      const dashFrame = lastFrame()!;
+      expect(dashFrame).toContain('unlocked');
+      expect(dashFrame).toMatch(/Keys:\s+1/);
+    });
+
+    it('main menu reflects pre-populated vault data', async () => {
+      // Use a vault with pre-populated data
+      await cleanup();
+      const result = await createTestVaultWithData();
+      testDir = result.dir;
+      result.vault.lock();
+      cleanup = result.cleanup;
+
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      type(stdin, TEST_PASSWORD);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('1 keys');
+    });
+
+    it('Dashboard shows RPC endpoint count from pre-populated vault', async () => {
+      await cleanup();
+      const result = await createTestVaultWithData();
+      testDir = result.dir;
+      result.vault.lock();
+      cleanup = result.cleanup;
+
+      const { stdin, lastFrame } = render(<App basePath={testDir} />);
+      await delay();
+      type(stdin, TEST_PASSWORD);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+
+      // Go to Dashboard
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Keys:\s+1/);
+      expect(frame).toMatch(/Endpoints:\s+1/);
+    });
+  });
+});

--- a/packages/cli/src/tui/components/MainMenu.e2e.test.tsx
+++ b/packages/cli/src/tui/components/MainMenu.e2e.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { MainMenu } from './MainMenu.js';
+import { KEYS } from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+describe('MainMenu e2e', () => {
+  it('renders all 6 menu items', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Dashboard');
+    expect(frame).toContain('Keys');
+    expect(frame).toContain('Agents');
+    expect(frame).toContain('Services');
+    expect(frame).toContain('Logs');
+    expect(frame).toContain('Rules');
+  });
+
+  it('shows key and agent counts in header', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={5} agentCount={3} onSelect={vi.fn()} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('5 keys');
+    expect(frame).toContain('3 agents');
+  });
+
+  it('first item (Dashboard) is selected by default with "> " prefix', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('> Dashboard');
+  });
+
+  it('down arrow moves selection to next item', async () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    await delay();
+    stdin.write(KEYS.DOWN);
+    await delay();
+
+    const frame = lastFrame()!;
+    expect(frame).toContain('> Keys');
+    expect(frame).not.toMatch(/> Dashboard/);
+  });
+
+  it('up arrow wraps from top to bottom (Dashboard wraps to Rules)', async () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    // Initially on Dashboard (index 0)
+    await delay();
+    stdin.write(KEYS.UP);
+    await delay();
+
+    const frame = lastFrame()!;
+    expect(frame).toContain('> Rules');
+  });
+
+  it('down arrow wraps from bottom to top', async () => {
+    const { stdin, lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    await delay();
+    // Navigate to the last item (Rules) — 5 down presses
+    for (let i = 0; i < 5; i++) {
+      stdin.write(KEYS.DOWN);
+    }
+    await delay();
+    expect(lastFrame()!).toContain('> Rules');
+
+    // One more down should wrap to Dashboard
+    stdin.write(KEYS.DOWN);
+    await delay();
+    expect(lastFrame()!).toContain('> Dashboard');
+  });
+
+  it('Enter on first item calls onSelect with "dashboard"', async () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+    );
+    await delay();
+    stdin.write(KEYS.ENTER);
+    await delay();
+    expect(onSelect).toHaveBeenCalledWith('dashboard');
+  });
+
+  it('navigate to Keys (down arrow) then Enter calls onSelect with "keys"', async () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+    );
+    await delay();
+    stdin.write(KEYS.DOWN);
+    await delay();
+    stdin.write(KEYS.ENTER);
+    await delay();
+    expect(onSelect).toHaveBeenCalledWith('keys');
+  });
+
+  it('navigate to each screen and verify onSelect receives correct value', async () => {
+    const screens = ['dashboard', 'keys', 'agents', 'services', 'logs', 'rules'] as const;
+
+    for (let i = 0; i < screens.length; i++) {
+      const onSelect = vi.fn();
+      const { stdin, unmount } = render(
+        <MainMenu keyCount={0} agentCount={0} onSelect={onSelect} />,
+      );
+      await delay();
+
+      // Navigate down i times from Dashboard to reach target
+      for (let j = 0; j < i; j++) {
+        stdin.write(KEYS.DOWN);
+      }
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(onSelect).toHaveBeenCalledWith(screens[i]);
+      unmount();
+    }
+  });
+
+  it('shows navigation help text', () => {
+    const { lastFrame } = render(
+      <MainMenu keyCount={0} agentCount={0} onSelect={vi.fn()} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('arrows navigate');
+    expect(frame).toContain('Enter select');
+  });
+});

--- a/packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx
+++ b/packages/cli/src/tui/components/PasswordPrompt.e2e.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { PasswordPrompt } from './PasswordPrompt.js';
+import { KEYS, type } from '../test-helpers.js';
+
+// ink needs a tick for useEffect (which registers the useInput listener via setRawMode)
+// to fire after the initial render. We need to await this before sending stdin input.
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+describe('PasswordPrompt e2e', () => {
+  it('renders dual-prompt (P/T options) when hasPasskey=true', () => {
+    const { lastFrame } = render(
+      <PasswordPrompt
+        onSubmit={vi.fn()}
+        hasPasskey={true}
+        onPasskeyRequest={vi.fn()}
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('[P]');
+    expect(frame).toContain('[T]');
+    expect(frame).toContain('Passkey');
+    expect(frame).toContain('Type password');
+  });
+
+  it('renders password-only mode when hasPasskey=false', () => {
+    const { lastFrame } = render(
+      <PasswordPrompt onSubmit={vi.fn()} hasPasskey={false} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Enter master vault password');
+    expect(frame).not.toContain('[P]');
+    expect(frame).not.toContain('[T]');
+  });
+
+  it('P key triggers onPasskeyRequest callback', async () => {
+    const onPasskeyRequest = vi.fn();
+    const { stdin } = render(
+      <PasswordPrompt
+        onSubmit={vi.fn()}
+        hasPasskey={true}
+        onPasskeyRequest={onPasskeyRequest}
+      />,
+    );
+    await delay();
+    stdin.write('P');
+    await delay();
+    expect(onPasskeyRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('p key (lowercase) also triggers onPasskeyRequest', async () => {
+    const onPasskeyRequest = vi.fn();
+    const { stdin } = render(
+      <PasswordPrompt
+        onSubmit={vi.fn()}
+        hasPasskey={true}
+        onPasskeyRequest={onPasskeyRequest}
+      />,
+    );
+    await delay();
+    stdin.write('p');
+    await delay();
+    expect(onPasskeyRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('T key switches to password input mode', async () => {
+    const { stdin, lastFrame } = render(
+      <PasswordPrompt
+        onSubmit={vi.fn()}
+        hasPasskey={true}
+        onPasskeyRequest={vi.fn()}
+      />,
+    );
+    // Initially in select mode
+    expect(lastFrame()!).toContain('[P]');
+
+    await delay();
+    stdin.write('T');
+    await delay();
+
+    // Now in password mode
+    const frame = lastFrame()!;
+    expect(frame).toContain('Enter master vault password');
+    expect(frame).not.toContain('[P]');
+  });
+
+  it('typing renders asterisks (masked characters)', async () => {
+    const { stdin, lastFrame } = render(
+      <PasswordPrompt onSubmit={vi.fn()} hasPasskey={false} />,
+    );
+    await delay();
+    type(stdin, 'abc');
+    await delay();
+    const frame = lastFrame()!;
+    expect(frame).toContain('***');
+    expect(frame).not.toContain('abc');
+  });
+
+  it('backspace removes last character', async () => {
+    const { stdin, lastFrame } = render(
+      <PasswordPrompt onSubmit={vi.fn()} hasPasskey={false} />,
+    );
+    await delay();
+    type(stdin, 'abcd');
+    await delay();
+    expect(lastFrame()!).toContain('****');
+
+    stdin.write(KEYS.BACKSPACE);
+    await delay();
+    expect(lastFrame()!).toContain('***');
+    expect(lastFrame()!).not.toContain('****');
+  });
+
+  it('Enter with empty password shows "Password cannot be empty" validation error', async () => {
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = render(
+      <PasswordPrompt onSubmit={onSubmit} hasPasskey={false} />,
+    );
+    await delay();
+    stdin.write(KEYS.ENTER);
+    await delay();
+    expect(lastFrame()!).toContain('Password cannot be empty');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('Enter with password calls onSubmit with correct value', async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <PasswordPrompt onSubmit={onSubmit} hasPasskey={false} />,
+    );
+    await delay();
+    type(stdin, 'my-secret-pass');
+    await delay();
+    stdin.write(KEYS.ENTER);
+    await delay();
+    expect(onSubmit).toHaveBeenCalledWith('my-secret-pass');
+  });
+
+  it('error prop displays error message', () => {
+    const { lastFrame } = render(
+      <PasswordPrompt
+        onSubmit={vi.fn()}
+        hasPasskey={false}
+        error="Invalid password"
+      />,
+    );
+    expect(lastFrame()!).toContain('Invalid password');
+  });
+
+  it('typing clears validation error', async () => {
+    const { stdin, lastFrame } = render(
+      <PasswordPrompt onSubmit={vi.fn()} hasPasskey={false} />,
+    );
+    await delay();
+    // Trigger validation error
+    stdin.write(KEYS.ENTER);
+    await delay();
+    expect(lastFrame()!).toContain('Password cannot be empty');
+
+    // Type a character - should clear the validation error
+    stdin.write('a');
+    await delay();
+    expect(lastFrame()!).not.toContain('Password cannot be empty');
+  });
+});

--- a/packages/cli/src/tui/screens/AgentsScreen.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/AgentsScreen.e2e.test.tsx
@@ -1,0 +1,655 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { AgentsScreen } from './AgentsScreen.js';
+import type { MasterVault, AgentVaultManager } from '@chainvault/core';
+import { createTestVaultWithData, KEYS, type, waitForRender } from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+const SAMPLE_AGENTS = [
+  { name: 'deployer', chains: [11155111], allowed_types: ['deploy', 'write', 'read'] },
+  { name: 'reader', chains: [1, 137], allowed_types: ['read', 'simulate'] },
+];
+
+function mockManager(): AgentVaultManager {
+  return {
+    createAgent: vi.fn(async () => ({ vaultKey: 'cv_agent_' + 'ab'.repeat(32) })),
+    revokeAgent: vi.fn(async () => {}),
+    listAgents: vi.fn(() => SAMPLE_AGENTS),
+  } as unknown as AgentVaultManager;
+}
+
+function mockVault(): MasterVault {
+  return {
+    isUnlocked: vi.fn(() => true),
+    getData: vi.fn(() => ({ agents: {} })),
+    saveData: vi.fn(async () => {}),
+  } as unknown as MasterVault;
+}
+
+describe('AgentsScreen e2e', () => {
+  // ── List mode ──────────────────────────────────────
+
+  describe('list mode', () => {
+    it('renders agents with names, chains, and tx types', () => {
+      const { lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('11155111');
+      expect(frame).toContain('deploy');
+      expect(frame).toContain('reader');
+      expect(frame).toContain('137');
+      expect(frame).toContain('simulate');
+    });
+
+    it('shows empty state when no agents', () => {
+      const { lastFrame } = render(
+        <AgentsScreen
+          agents={[]}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('No agents configured');
+    });
+
+    it('arrow navigation highlights different agents', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      // Initially first agent is selected
+      expect(lastFrame()!).toContain('> ');
+      expect(lastFrame()!).toMatch(/>\s+deployer/);
+
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+
+      const frame = lastFrame()!;
+      // reader should now have the selection indicator
+      expect(frame).toMatch(/>\s+reader/);
+    });
+
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const { stdin } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={onBack}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows help text with a add, d revoke', () => {
+      const { lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('a add');
+      expect(frame).toContain('d revoke');
+    });
+  });
+
+  // ── Create flow ────────────────────────────────────
+
+  describe('create flow', () => {
+    it('"a" enters create-name mode', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      expect(lastFrame()!).toContain('Agent name');
+    });
+
+    it('empty name shows validation error', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Name cannot be empty');
+    });
+
+    it('valid name advances to create-chains mode', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'test-agent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Chain IDs');
+    });
+
+    it('invalid chain IDs show error', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Enter create-name mode
+      stdin.write('a');
+      await delay();
+      type(stdin, 'myagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Now in create-chains mode, type invalid chain
+      type(stdin, 'abc');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Invalid chain ID');
+    });
+
+    it('valid chains advance to create-types mode', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'myagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Tx types');
+    });
+
+    it('invalid tx types show error', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'myagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'hack');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Invalid tx type');
+    });
+
+    it('valid types creates agent and shows vault key', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'newagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'deploy,read');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      // Wait longer for async createAgent to resolve
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('cv_agent_');
+      expect(frame).toContain('Save this vault key');
+      expect(mgr.createAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('vault key matches cv_agent_ format', async () => {
+      const mgr = mockManager();
+      (mgr.createAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+        vaultKey: 'cv_agent_' + 'cd'.repeat(32),
+      });
+
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'testagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'read');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/cv_agent_[a-f0-9]{64}/);
+    });
+
+    it('any key after vault key display returns to list', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Navigate through full create flow
+      stdin.write('a');
+      await delay();
+      type(stdin, 'myagent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'read');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      // Should be on show-key screen
+      expect(lastFrame()!).toContain('cv_agent_');
+
+      // Press any key to go back to list
+      stdin.write(' ');
+      await delay();
+
+      const frame = lastFrame()!;
+      // Should be back in list mode -- shows the help text
+      expect(frame).toContain('a add');
+      expect(frame).toContain('d revoke');
+    });
+
+    it('Esc during create-name returns to list without creating', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      expect(lastFrame()!).toContain('Agent name');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      // Back to list
+      expect(lastFrame()!).toContain('a add');
+      expect(mgr.createAgent).not.toHaveBeenCalled();
+    });
+
+    it('Esc during create-chains goes back to create-name', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'test');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Chain IDs');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(lastFrame()!).toContain('Agent name');
+    });
+
+    it('Esc during create-types goes back to create-chains', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'test');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Tx types');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(lastFrame()!).toContain('Chain IDs');
+    });
+  });
+
+  // ── Revoke flow ────────────────────────────────────
+
+  describe('revoke flow', () => {
+    it('"d" shows revoke confirmation', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mockManager()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      const frame = lastFrame()!;
+      expect(frame).toContain('Revoke agent');
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('y/n');
+    });
+
+    it('"y" calls revokeAgent', async () => {
+      const mgr = mockManager();
+      const { stdin } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('y');
+      await delay(300);
+      expect(mgr.revokeAgent).toHaveBeenCalledWith('deployer');
+    });
+
+    it('"n" cancels revoke and returns to list', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      expect(lastFrame()!).toContain('Revoke agent');
+
+      stdin.write('n');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('a add');
+      expect(frame).toContain('d revoke');
+      expect(mgr.revokeAgent).not.toHaveBeenCalled();
+    });
+
+    it('Esc cancels revoke and returns to list', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      expect(lastFrame()!).toContain('Revoke agent');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      expect(lastFrame()!).toContain('a add');
+      expect(mgr.revokeAgent).not.toHaveBeenCalled();
+    });
+
+    it('revoke targets the selected agent after navigation', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Navigate to second agent (reader)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      expect(lastFrame()!).toContain('reader');
+      expect(lastFrame()!).toContain('y/n');
+
+      stdin.write('y');
+      await delay(300);
+      expect(mgr.revokeAgent).toHaveBeenCalledWith('reader');
+    });
+
+    it('"d" does nothing when there are no agents', async () => {
+      const mgr = mockManager();
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={[]}
+          masterVault={mockVault()}
+          agentManager={mgr}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      // Should still show the list mode with empty state, not confirm-revoke
+      expect(lastFrame()!).toContain('No agents configured');
+      expect(lastFrame()!).not.toContain('y/n');
+    });
+  });
+
+  // ── Real vault roundtrip ───────────────────────────
+
+  describe('real vault roundtrip', () => {
+    let testDir: string;
+    let vault: MasterVault;
+    let manager: AgentVaultManager;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await createTestVaultWithData();
+      testDir = result.dir;
+      vault = result.vault;
+      manager = result.manager;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it('creates agent with real AgentVaultManager and vault file exists on disk', async () => {
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={[]}
+          masterVault={vault}
+          agentManager={manager}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Start create flow
+      stdin.write('a');
+      await delay();
+      type(stdin, 'real-agent');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'deploy,read');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(500);
+
+      // Should show vault key
+      const frame = lastFrame()!;
+      expect(frame).toContain('cv_agent_');
+      expect(frame).toMatch(/cv_agent_[a-f0-9]{64}/);
+
+      // Vault file should exist on disk
+      const vaultPath = join(testDir, 'agents', 'real-agent.vault');
+      expect(existsSync(vaultPath)).toBe(true);
+    });
+
+    it('revokes agent with real AgentVaultManager and vault file is removed', async () => {
+      // First create an agent directly so we have one to revoke
+      const agentConfig = {
+        name: 'to-revoke',
+        chains: [11155111],
+        tx_rules: { allowed_types: ['read' as const], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' as const },
+      };
+      await manager.createAgent(agentConfig, [], []);
+      const vaultPath = join(testDir, 'agents', 'to-revoke.vault');
+      expect(existsSync(vaultPath)).toBe(true);
+
+      const agentsList = [
+        { name: 'to-revoke', chains: [11155111], allowed_types: ['read'] },
+      ];
+
+      const { stdin, lastFrame } = render(
+        <AgentsScreen
+          agents={agentsList}
+          masterVault={vault}
+          agentManager={manager}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Revoke the agent
+      stdin.write('d');
+      await delay();
+      expect(lastFrame()!).toContain('to-revoke');
+      expect(lastFrame()!).toContain('y/n');
+
+      stdin.write('y');
+      await delay(500);
+
+      // Vault file should be removed
+      expect(existsSync(vaultPath)).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/tui/screens/Dashboard.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/Dashboard.e2e.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect } from 'vitest';
+import { Dashboard } from './Dashboard.js';
+import { KEYS } from '../test-helpers.js';
+import type { AuditEntry } from '@chainvault/core';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+const SAMPLE_ACTIVITY: AuditEntry[] = [
+  {
+    timestamp: '2026-03-20T10:15:30.000Z',
+    agent: 'deployer',
+    action: 'deploy_contract',
+    chain_id: 11155111,
+    status: 'approved',
+    details: 'deployed to sepolia',
+  },
+  {
+    timestamp: '2026-03-20T10:16:00.000Z',
+    agent: 'reader',
+    action: 'get_balance',
+    chain_id: 1,
+    status: 'approved',
+    details: 'read balance',
+  },
+  {
+    timestamp: '2026-03-20T10:17:00.000Z',
+    agent: 'deployer',
+    action: 'transfer',
+    chain_id: 1,
+    status: 'denied',
+    details: 'chain not allowed',
+  },
+];
+
+describe('Dashboard e2e', () => {
+  // ── Display ────────────────────────────────────────────
+
+  describe('display', () => {
+    it('displays the vault path', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/home/user/.chainvault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      expect(lastFrame()!).toContain('/home/user/.chainvault');
+    });
+
+    it('shows "unlocked" status', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      expect(lastFrame()!).toContain('unlocked');
+    });
+
+    it('shows key count, agent count, and RPC count', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={3}
+          agentCount={2}
+          rpcCount={5}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('3');
+      expect(frame).toContain('2');
+      expect(frame).toContain('5');
+      expect(frame).toContain('Keys');
+      expect(frame).toContain('Agents');
+      expect(frame).toContain('Endpoints');
+    });
+
+    it('shows recent activity entries with timestamp, agent, and action', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={1}
+          agentCount={1}
+          rpcCount={1}
+          recentActivity={SAMPLE_ACTIVITY}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      // Timestamps are sliced to show HH:MM:SS
+      expect(frame).toContain('10:15:30');
+      expect(frame).toContain('10:16:00');
+      expect(frame).toContain('10:17:00');
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('reader');
+      expect(frame).toContain('deploy_contract');
+      expect(frame).toContain('get_balance');
+      expect(frame).toContain('transfer');
+    });
+
+    it('shows + indicator for approved activity', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[SAMPLE_ACTIVITY[0]]}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('+');
+      expect(frame).toContain('deployer');
+    });
+
+    it('shows x indicator for denied activity', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[SAMPLE_ACTIVITY[2]]}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('x');
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('transfer');
+    });
+
+    it('shows "No activity yet" when recentActivity is empty', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      expect(lastFrame()!).toContain('No activity yet');
+    });
+
+    it('shows [R] Register passkey help text', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('[R] Register passkey');
+      expect(frame).toContain('Esc back');
+    });
+  });
+
+  // ── Navigation ─────────────────────────────────────────
+
+  describe('navigation', () => {
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const { stdin } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={onBack}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Resource counts ────────────────────────────────────
+
+  describe('resource counts', () => {
+    it('shows zero counts correctly', () => {
+      const { lastFrame } = render(
+        <Dashboard
+          vaultPath="/tmp/vault"
+          keyCount={0}
+          agentCount={0}
+          rpcCount={0}
+          recentActivity={[]}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Keys:\s+0/);
+      expect(frame).toMatch(/Agents:\s+0/);
+      expect(frame).toMatch(/Endpoints:\s+0/);
+    });
+  });
+});

--- a/packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/KeysScreen.e2e.test.tsx
@@ -1,0 +1,677 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { KeysScreen } from './KeysScreen.js';
+import type { KeyInfo } from './KeysScreen.js';
+import {
+  KEYS,
+  type,
+  createTestVault,
+  TEST_PRIVATE_KEY,
+  waitForRender,
+} from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+const MOCK_KEYS: KeyInfo[] = [
+  {
+    name: 'wallet-1',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    chains: [1, 11155111],
+  },
+  {
+    name: 'wallet-2',
+    address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+    chains: [137],
+  },
+];
+
+describe('KeysScreen e2e', () => {
+  // ─── List Mode ────────────────────────────────────────────────
+
+  describe('list mode', () => {
+    it('renders keys with names, addresses, and chains', () => {
+      const { lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('wallet-1');
+      expect(frame).toContain('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+      expect(frame).toContain('1, 11155111');
+      expect(frame).toContain('wallet-2');
+      expect(frame).toContain('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+      expect(frame).toContain('137');
+    });
+
+    it('shows empty state when no keys', () => {
+      const { lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('No keys stored');
+    });
+
+    it('arrow navigation highlights different keys', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      // First key selected by default
+      expect(lastFrame()!).toContain('> ');
+      expect(lastFrame()!).toMatch(/>\s.*wallet-1/);
+
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+
+      const frame = lastFrame()!;
+      // wallet-2 should now be highlighted
+      expect(frame).toMatch(/>\s.*wallet-2/);
+    });
+
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const { stdin } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={onBack}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows help text with a add, d delete', () => {
+      const { lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('a add');
+      expect(frame).toContain('d delete');
+      expect(frame).toContain('Esc back');
+    });
+
+    it('up arrow does not go past first item', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.UP);
+      await delay();
+      // Still on first item
+      expect(lastFrame()!).toMatch(/>\s.*wallet-1/);
+    });
+  });
+
+  // ─── Add Flow ─────────────────────────────────────────────────
+
+  describe('add flow', () => {
+    it('pressing a enters add-name mode and shows "Key name" prompt', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Key name');
+    });
+
+    it('empty name and Enter shows validation error', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Name cannot be empty');
+    });
+
+    it('valid name and Enter proceeds to private key prompt', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Private key');
+      expect(frame).toContain('my-key');
+    });
+
+    it('empty private key and Enter shows error', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Now in add-key mode, press Enter without typing
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Private key cannot be empty');
+    });
+
+    it('private key input is shown as asterisks, not raw text', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Type some private key chars
+      type(stdin, '0xabc');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('*****');
+      expect(frame).not.toContain('0xabc');
+    });
+
+    it('valid private key proceeds to chain IDs prompt', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '0xdeadbeef');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Chain IDs');
+    });
+
+    it('empty chain IDs and Enter shows error', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '0xdeadbeef');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Now in add-chains mode, press Enter without typing
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Chain IDs cannot be empty');
+    });
+
+    it('invalid chain ID shows error', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '0xdeadbeef');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'abc');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Invalid chain ID');
+    });
+
+    it('complete add flow calls onAddKey with correct args', async () => {
+      const onAddKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={onAddKey}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Enter add mode
+      stdin.write('a');
+      await delay();
+      // Type name
+      type(stdin, 'test-wallet');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Type private key
+      type(stdin, '0xdeadbeef1234');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Type chain IDs
+      type(stdin, '1,11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(200);
+
+      expect(onAddKey).toHaveBeenCalledWith(
+        'test-wallet',
+        '0xdeadbeef1234',
+        [1, 11155111],
+      );
+    });
+
+    it('Esc during add-name returns to list without mutation', async () => {
+      const onAddKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={onAddKey}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      expect(lastFrame()!).toContain('Key name');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      // Back in list mode
+      const frame = lastFrame()!;
+      expect(frame).toContain('wallet-1');
+      expect(frame).toContain('a add');
+      expect(onAddKey).not.toHaveBeenCalled();
+    });
+
+    it('backspace removes character in name input', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'abcd');
+      await delay();
+      expect(lastFrame()!).toContain('abcd');
+
+      stdin.write(KEYS.BACKSPACE);
+      await delay();
+      const frame = lastFrame()!;
+      expect(frame).toContain('abc');
+      expect(frame).not.toContain('abcd');
+    });
+
+    it('Esc during add-key goes back to add-name', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Now in add-key mode
+      expect(lastFrame()!).toContain('Private key');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      // Back in add-name mode
+      expect(lastFrame()!).toContain('Key name');
+    });
+
+    it('Esc during add-chains goes back to add-key', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'my-key');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '0xdeadbeef');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Now in add-chains mode
+      expect(lastFrame()!).toContain('Chain IDs');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      // Back in add-key mode
+      expect(lastFrame()!).toContain('Private key');
+    });
+  });
+
+  // ─── Delete Flow ──────────────────────────────────────────────
+
+  describe('delete flow', () => {
+    it('pressing d shows delete confirmation with key name', async () => {
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Delete');
+      expect(frame).toContain('wallet-1');
+      expect(frame).toContain('y/n');
+    });
+
+    it('y confirms deletion and calls onRemoveKey with key name', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={onRemoveKey}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('y');
+      await waitForRender(200);
+
+      expect(onRemoveKey).toHaveBeenCalledWith('wallet-1');
+    });
+
+    it('n cancels deletion and returns to list', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={onRemoveKey}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('n');
+      await delay();
+
+      // Back in list mode, key still shown
+      const frame = lastFrame()!;
+      expect(frame).toContain('wallet-1');
+      expect(frame).toContain('a add');
+      expect(onRemoveKey).not.toHaveBeenCalled();
+    });
+
+    it('navigate to second key then delete passes correct name', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={MOCK_KEYS}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={onRemoveKey}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Move to second key
+      stdin.write(KEYS.DOWN);
+      await delay();
+      expect(lastFrame()!).toMatch(/>\s.*wallet-2/);
+
+      stdin.write('d');
+      await delay();
+      // Confirm shows wallet-2
+      expect(lastFrame()!).toContain('wallet-2');
+
+      stdin.write('y');
+      await waitForRender(200);
+
+      expect(onRemoveKey).toHaveBeenCalledWith('wallet-2');
+    });
+
+    it('d is ignored when keys list is empty', async () => {
+      const onRemoveKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin, lastFrame } = render(
+        <KeysScreen
+          keys={[]}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={onRemoveKey}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      // Still in list mode showing empty state
+      const frame = lastFrame()!;
+      expect(frame).toContain('No keys stored');
+      expect(frame).not.toContain('Delete');
+    });
+  });
+
+  // ─── Real Vault Roundtrip ─────────────────────────────────────
+
+  describe('real vault roundtrip', () => {
+    let testDir: string;
+    let vault: Awaited<ReturnType<typeof createTestVault>>['vault'];
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await createTestVault();
+      testDir = result.dir;
+      vault = result.vault;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it('add key via callbacks then verify vault.listKeys() reflects it', async () => {
+      // Start with empty keys
+      const currentKeys: KeyInfo[] = [];
+
+      const onAddKey = async (name: string, privateKey: string, chains: number[]) => {
+        await vault.addKey(name, privateKey, chains);
+      };
+
+      const { stdin } = render(
+        <KeysScreen
+          keys={currentKeys}
+          onAddKey={onAddKey}
+          onRemoveKey={vi.fn().mockResolvedValue(undefined)}
+          onBack={vi.fn()}
+        />,
+      );
+
+      await delay();
+      // Enter add flow
+      stdin.write('a');
+      await delay();
+      type(stdin, 'real-wallet');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, TEST_PRIVATE_KEY);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '1,11155111');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(300);
+
+      // Verify the vault actually has the key
+      const storedKeys = vault.listKeys();
+      expect(storedKeys).toHaveLength(1);
+      expect(storedKeys[0].name).toBe('real-wallet');
+      expect(storedKeys[0].address).toBe(
+        '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      );
+      expect(storedKeys[0].chains).toEqual([1, 11155111]);
+    });
+
+    it('remove key via callbacks then verify vault.listKeys() is empty', async () => {
+      // Pre-populate the vault with a key
+      await vault.addKey('to-delete', TEST_PRIVATE_KEY, [1]);
+      const currentKeys: KeyInfo[] = [
+        {
+          name: 'to-delete',
+          address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          chains: [1],
+        },
+      ];
+
+      const onRemoveKey = async (name: string) => {
+        await vault.removeKey(name);
+      };
+
+      const { stdin } = render(
+        <KeysScreen
+          keys={currentKeys}
+          onAddKey={vi.fn().mockResolvedValue(undefined)}
+          onRemoveKey={onRemoveKey}
+          onBack={vi.fn()}
+        />,
+      );
+
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('y');
+      await waitForRender(300);
+
+      // Verify the vault is now empty
+      const storedKeys = vault.listKeys();
+      expect(storedKeys).toHaveLength(0);
+    });
+  });
+});

--- a/packages/cli/src/tui/screens/LogsScreen.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/LogsScreen.e2e.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ChainVaultDB, AuditStore } from '@chainvault/core';
+import { LogsScreen } from './LogsScreen.js';
+import { KEYS } from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+function createMockAuditStore(entries: Array<{
+  timestamp: string;
+  agent: string;
+  action: string;
+  chain_id: number;
+  status: 'approved' | 'denied';
+  details: string;
+}>): AuditStore {
+  return {
+    getEntries: vi.fn((filter?: { status?: 'approved' | 'denied' }) => {
+      if (!filter) return entries;
+      return entries.filter((e) => e.status === filter.status);
+    }),
+  } as unknown as AuditStore;
+}
+
+const SAMPLE_ENTRIES = [
+  { timestamp: '2026-03-20T10:00:00.000Z', agent: 'deployer', action: 'deploy', chain_id: 11155111, status: 'approved' as const, details: 'deployed contract' },
+  { timestamp: '2026-03-20T10:01:00.000Z', agent: 'reader', action: 'read', chain_id: 1, status: 'approved' as const, details: 'read balance' },
+  { timestamp: '2026-03-20T10:02:00.000Z', agent: 'deployer', action: 'transfer', chain_id: 1, status: 'denied' as const, details: 'chain not allowed' },
+  { timestamp: '2026-03-20T10:03:00.000Z', agent: 'reader', action: 'write', chain_id: 137, status: 'denied' as const, details: 'tx type not allowed' },
+];
+
+describe('LogsScreen e2e', () => {
+  // ── Display ──────────────────────────────────────────
+
+  describe('display', () => {
+    it('renders audit entries with timestamps, agent names, and actions', () => {
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('2026-03-20T10:00:00');
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('deploy');
+      expect(frame).toContain('reader');
+      expect(frame).toContain('read');
+    });
+
+    it('shows green indicator for approved entries', () => {
+      const store = createMockAuditStore([SAMPLE_ENTRIES[0]]);
+      const { lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      // The component renders '+' for approved entries
+      expect(frame).toContain('+');
+      expect(frame).toContain('deployer');
+    });
+
+    it('shows red indicator for denied entries', () => {
+      const store = createMockAuditStore([SAMPLE_ENTRIES[2]]);
+      const { lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      // The component renders 'x' for denied entries
+      expect(frame).toContain('x');
+      expect(frame).toContain('deployer');
+    });
+
+    it('shows "No log entries" when empty', () => {
+      const store = createMockAuditStore([]);
+      const { lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('No log entries');
+    });
+
+    it('shows page count', () => {
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      // 4 entries, PAGE_SIZE=15, so page 1/1
+      expect(frame).toContain('page 1/1');
+    });
+  });
+
+  // ── Filter cycling ───────────────────────────────────
+
+  describe('filter cycling (f key)', () => {
+    it('f cycles: all -> approved -> denied -> all', async () => {
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      // Initial: filter = all
+      expect(lastFrame()!).toMatch(/Filter:\s+all/);
+
+      await delay();
+      stdin.write('f');
+      await delay();
+      expect(lastFrame()!).toMatch(/Filter:\s+approved/);
+
+      await delay();
+      stdin.write('f');
+      await delay();
+      expect(lastFrame()!).toMatch(/Filter:\s+denied/);
+
+      await delay();
+      stdin.write('f');
+      await delay();
+      expect(lastFrame()!).toMatch(/Filter:\s+all/);
+    });
+
+    it('filter "approved" shows only approved entries', async () => {
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      await delay();
+      stdin.write('f');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Filter:\s+approved/);
+      // getEntries should have been called with { status: 'approved' }
+      expect(store.getEntries).toHaveBeenCalledWith({ status: 'approved' }, 200);
+    });
+
+    it('filter "denied" shows only denied entries', async () => {
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      await delay();
+      stdin.write('f');
+      await delay();
+      stdin.write('f');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Filter:\s+denied/);
+      expect(store.getEntries).toHaveBeenCalledWith({ status: 'denied' }, 200);
+    });
+  });
+
+  // ── Scrolling ────────────────────────────────────────
+
+  describe('scrolling', () => {
+    it('down arrow scrolls log entries', async () => {
+      // Create 20 entries so we can scroll beyond PAGE_SIZE (15)
+      const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+        timestamp: `2026-03-20T10:${String(i).padStart(2, '0')}:00.000Z`,
+        agent: `agent-${i}`,
+        action: 'read',
+        chain_id: 1,
+        status: 'approved' as const,
+        details: `entry ${i}`,
+      }));
+      const store = createMockAuditStore(manyEntries);
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+      // Initially we see agent-0
+      expect(lastFrame()!).toContain('agent-0');
+
+      await delay();
+      // Scroll down enough to push agent-0 out of view
+      for (let i = 0; i < 5; i++) {
+        stdin.write(KEYS.DOWN);
+      }
+      await delay();
+
+      const frame = lastFrame()!;
+      // After scrolling down 5 times, agent-5 should be visible (first visible)
+      expect(frame).toContain('agent-5');
+    });
+
+    it('up arrow scrolls back up', async () => {
+      const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+        timestamp: `2026-03-20T10:${String(i).padStart(2, '0')}:00.000Z`,
+        agent: `agent-${i}`,
+        action: 'read',
+        chain_id: 1,
+        status: 'approved' as const,
+        details: `entry ${i}`,
+      }));
+      const store = createMockAuditStore(manyEntries);
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={store} onBack={vi.fn()} />,
+      );
+
+      await delay();
+      // Scroll down 5
+      for (let i = 0; i < 5; i++) {
+        stdin.write(KEYS.DOWN);
+      }
+      await delay();
+      expect(lastFrame()!).toContain('agent-5');
+
+      // Scroll back up 3
+      for (let i = 0; i < 3; i++) {
+        stdin.write(KEYS.UP);
+      }
+      await delay();
+
+      const frame = lastFrame()!;
+      // After scrolling up 3 from offset 5, we should be at offset 2
+      expect(frame).toContain('agent-2');
+    });
+  });
+
+  // ── Esc calls onBack ────────────────────────────────
+
+  describe('navigation', () => {
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const store = createMockAuditStore(SAMPLE_ENTRIES);
+      const { stdin } = render(
+        <LogsScreen auditStore={store} onBack={onBack} />,
+      );
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Real AuditStore roundtrip ────────────────────────
+
+  describe('real AuditStore roundtrip', () => {
+    let testDir: string;
+    let db: ChainVaultDB;
+    let auditStore: AuditStore;
+
+    beforeEach(async () => {
+      testDir = await mkdtemp(join(tmpdir(), 'cv-logs-test-'));
+      db = new ChainVaultDB(testDir);
+      auditStore = new AuditStore(db);
+    });
+
+    afterEach(async () => {
+      db.close();
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    it('displays entries added via real AuditStore', () => {
+      // Add 20 mixed entries
+      for (let i = 0; i < 20; i++) {
+        auditStore.log({
+          agent: `agent-${i}`,
+          action: i % 2 === 0 ? 'deploy' : 'read',
+          chain_id: i % 2 === 0 ? 11155111 : 1,
+          status: i % 3 === 0 ? 'denied' : 'approved',
+          details: `entry ${i}`,
+        });
+      }
+
+      const { lastFrame } = render(
+        <LogsScreen auditStore={auditStore} onBack={vi.fn()} />,
+      );
+      const frame = lastFrame()!;
+      // Should display entries (most recent first, getEntries is DESC order)
+      expect(frame).toContain('20 entries');
+      expect(frame).toContain('Audit Logs');
+      // page count: 20 entries / 15 per page = 2 pages
+      expect(frame).toContain('page 1/2');
+    });
+
+    it('filter to approved only shows correct count', async () => {
+      for (let i = 0; i < 20; i++) {
+        auditStore.log({
+          agent: `agent-${i}`,
+          action: 'read',
+          chain_id: 1,
+          status: i % 3 === 0 ? 'denied' : 'approved',
+          details: `entry ${i}`,
+        });
+      }
+      // denied: i=0,3,6,9,12,15,18 => 7 denied, 13 approved
+
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={auditStore} onBack={vi.fn()} />,
+      );
+      // Initial: all 20
+      expect(lastFrame()!).toContain('20 entries');
+
+      await delay();
+      stdin.write('f');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Filter:\s+approved/);
+      expect(frame).toContain('13 entries');
+    });
+
+    it('filter to denied only shows correct count', async () => {
+      for (let i = 0; i < 20; i++) {
+        auditStore.log({
+          agent: `agent-${i}`,
+          action: 'read',
+          chain_id: 1,
+          status: i % 3 === 0 ? 'denied' : 'approved',
+          details: `entry ${i}`,
+        });
+      }
+      // 7 denied
+
+      const { stdin, lastFrame } = render(
+        <LogsScreen auditStore={auditStore} onBack={vi.fn()} />,
+      );
+
+      await delay();
+      // Press f twice to get to 'denied'
+      stdin.write('f');
+      await delay();
+      stdin.write('f');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/Filter:\s+denied/);
+      expect(frame).toContain('7 entries');
+    });
+  });
+});

--- a/packages/cli/src/tui/screens/RulesScreen.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/RulesScreen.e2e.test.tsx
@@ -1,0 +1,720 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RulesScreen } from './RulesScreen.js';
+import type { MasterVault } from '@chainvault/core';
+import { createTestVault, KEYS, type, waitForRender } from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+const SAMPLE_AGENTS = [
+  { name: 'deployer', chains: [11155111], allowed_types: ['deploy', 'write', 'read'] },
+  { name: 'reader', chains: [1, 137], allowed_types: ['read', 'simulate'] },
+];
+
+function mockVault(): MasterVault {
+  return {
+    isUnlocked: vi.fn(() => true),
+    getData: vi.fn(() => ({
+      version: 1,
+      keys: {},
+      api_keys: {},
+      rpc_endpoints: {},
+      agents: {
+        deployer: {
+          name: 'deployer',
+          chains: [11155111],
+          tx_rules: { allowed_types: ['deploy', 'write', 'read'], limits: {} },
+          api_access: {},
+          contract_rules: { mode: 'none' },
+        },
+        reader: {
+          name: 'reader',
+          chains: [1, 137],
+          tx_rules: { allowed_types: ['read', 'simulate'], limits: {} },
+          api_access: {},
+          contract_rules: { mode: 'none' },
+        },
+      },
+    })),
+    saveData: vi.fn(async () => {}),
+  } as unknown as MasterVault;
+}
+
+describe('RulesScreen e2e', () => {
+  // ── Agent selection mode ──────────────────────────────
+
+  describe('agent selection mode', () => {
+    it('lists agents with names, chains, and tx types', () => {
+      const { lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('11155111');
+      expect(frame).toContain('deploy');
+      expect(frame).toContain('reader');
+      expect(frame).toContain('137');
+      expect(frame).toContain('simulate');
+    });
+
+    it('arrow navigation highlights different agents', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      // Initially first agent is selected
+      expect(lastFrame()!).toMatch(/>\s+deployer/);
+
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+
+      expect(lastFrame()!).toMatch(/>\s+reader/);
+    });
+
+    it('Enter selects agent and shows edit menu', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Editing');
+      expect(frame).toContain('deployer');
+      expect(frame).toContain('Edit Chains');
+    });
+
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const { stdin } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={onBack}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('empty agents list shows appropriate state', () => {
+      const { lastFrame } = render(
+        <RulesScreen
+          agents={[]}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('No agents configured');
+    });
+  });
+
+  // ── Edit menu ─────────────────────────────────────────
+
+  describe('edit menu', () => {
+    it('shows 4 options: Edit Chains, Edit Tx Types, Edit Limits, Back', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Edit Chains');
+      expect(frame).toContain('Edit Tx Types');
+      expect(frame).toContain('Edit Limits');
+      expect(frame).toContain('Back');
+    });
+
+    it('navigate with arrows and select Edit Chains with Enter', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // First item is Edit Chains, press Enter
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Chains for');
+      expect(frame).toContain('deployer');
+    });
+
+    it('navigate to Edit Tx Types with down arrow', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Tx types for');
+      expect(frame).toContain('deployer');
+    });
+
+    it('"Back" menu item returns to agent selection', async () => {
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mockVault()}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Navigate to "Back" (4th item, index 3)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Select agent to edit');
+    });
+  });
+
+  // ── Edit chains ───────────────────────────────────────
+
+  describe('edit chains', () => {
+    it('type valid chain IDs and Enter saves with success message', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Select agent
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Select Edit Chains
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled input and type new chains
+      // The input is pre-filled with current chains "11155111"
+      // We need to clear it first, then type new value
+      for (let i = 0; i < 10; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, '1,137');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Chains updated');
+      expect(mv.saveData).toHaveBeenCalled();
+    });
+
+    it('invalid chain IDs show error and vault is unchanged', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear and type invalid chain ID
+      for (let i = 0; i < 10; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, 'abc');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Invalid chain ID');
+      expect(mv.saveData).not.toHaveBeenCalled();
+    });
+
+    it('empty chain input shows error', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear all pre-filled input
+      for (let i = 0; i < 10; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('cannot be empty');
+    });
+  });
+
+  // ── Edit tx types ─────────────────────────────────────
+
+  describe('edit tx types', () => {
+    it('type valid types and Enter saves with success message', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Navigate to Edit Tx Types (second item)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled input
+      for (let i = 0; i < 20; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, 'deploy,read,simulate');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Tx types updated');
+      expect(mv.saveData).toHaveBeenCalled();
+    });
+
+    it('invalid type shows error', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled input
+      for (let i = 0; i < 20; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, 'hack');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Invalid tx type');
+      expect(mv.saveData).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Edit limits ───────────────────────────────────────
+
+  describe('edit limits', () => {
+    it('type valid limit format and Enter saves', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Navigate to Edit Limits (third item)
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      type(stdin, '1:0.5:5.0:50.0');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Limits updated');
+      expect(mv.saveData).toHaveBeenCalled();
+    });
+
+    it('malformed format shows error', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      type(stdin, 'bad-format');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Format');
+      expect(mv.saveData).not.toHaveBeenCalled();
+    });
+
+    it('empty limits input shows error', async () => {
+      const mv = mockVault();
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={SAMPLE_AGENTS}
+          masterVault={mv}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Press Enter with empty input
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('cannot be empty');
+    });
+  });
+
+  // ── Real vault roundtrip ──────────────────────────────
+
+  describe('real vault roundtrip', () => {
+    let testDir: string;
+    let vault: Awaited<ReturnType<typeof createTestVault>>['vault'];
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await createTestVault();
+      testDir = result.dir;
+      vault = result.vault;
+      cleanup = result.cleanup;
+
+      // Add an agent config to the vault
+      const data = vault.getData();
+      data.agents['test-agent'] = {
+        name: 'test-agent',
+        chains: [1],
+        tx_rules: { allowed_types: ['read'], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' },
+      };
+      await vault.saveData();
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it('edit chains updates vault.getData().agents[name].chains', async () => {
+      const agents = [{ name: 'test-agent', chains: [1], allowed_types: ['read'] }];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Select agent
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Select Edit Chains
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled "1" and type new chains
+      stdin.write(KEYS.BACKSPACE);
+      await delay();
+      type(stdin, '1,137,42161');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Chains updated');
+
+      // Verify vault data was actually updated
+      const updatedData = vault.getData();
+      expect(updatedData.agents['test-agent'].chains).toEqual([1, 137, 42161]);
+    });
+
+    it('edit tx types updates vault.getData().agents[name].tx_rules.allowed_types', async () => {
+      const agents = [{ name: 'test-agent', chains: [1], allowed_types: ['read'] }];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Navigate to Edit Tx Types
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled "read" and type new types
+      for (let i = 0; i < 5; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, 'deploy,write,read');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Tx types updated');
+
+      const updatedData = vault.getData();
+      expect(updatedData.agents['test-agent'].tx_rules.allowed_types).toEqual([
+        'deploy',
+        'write',
+        'read',
+      ]);
+    });
+
+    it('edit limits updates vault.getData().agents[name].tx_rules.limits', async () => {
+      const agents = [{ name: 'test-agent', chains: [1], allowed_types: ['read'] }];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Navigate to Edit Limits
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      type(stdin, '1:0.5:5.0:50.0');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Limits updated');
+
+      const updatedData = vault.getData();
+      expect(updatedData.agents['test-agent'].tx_rules.limits['1']).toEqual({
+        max_per_tx: '0.5',
+        daily_limit: '5.0',
+        monthly_limit: '50.0',
+      });
+    });
+
+    it('Esc from edit-chains returns to edit menu without saving', async () => {
+      const agents = [{ name: 'test-agent', chains: [1], allowed_types: ['read'] }];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Type something but Esc before saving
+      type(stdin, '999');
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      // Should be back in edit menu
+      const frame = lastFrame()!;
+      expect(frame).toContain('Edit Chains');
+
+      // Vault should still have original chains
+      const data = vault.getData();
+      expect(data.agents['test-agent'].chains).toEqual([1]);
+    });
+
+    it('Esc from edit menu returns to agent selection', async () => {
+      const agents = [{ name: 'test-agent', chains: [1], allowed_types: ['read'] }];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      expect(lastFrame()!).toContain('Editing');
+
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+
+      expect(lastFrame()!).toContain('Select agent to edit');
+    });
+
+    it('selecting second agent then editing changes the correct agent', async () => {
+      // Add a second agent
+      const data = vault.getData();
+      data.agents['second-agent'] = {
+        name: 'second-agent',
+        chains: [137],
+        tx_rules: { allowed_types: ['simulate'], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' },
+      };
+      await vault.saveData();
+
+      const agents = [
+        { name: 'test-agent', chains: [1], allowed_types: ['read'] },
+        { name: 'second-agent', chains: [137], allowed_types: ['simulate'] },
+      ];
+
+      const { stdin, lastFrame } = render(
+        <RulesScreen
+          agents={agents}
+          masterVault={vault}
+          onBack={vi.fn()}
+        />,
+      );
+      await delay();
+      // Navigate to second agent
+      stdin.write(KEYS.DOWN);
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('second-agent');
+
+      // Edit Chains
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      // Clear pre-filled "137" and type new chains
+      for (let i = 0; i < 5; i++) {
+        stdin.write(KEYS.BACKSPACE);
+        await waitForRender(20);
+      }
+      type(stdin, '1,10');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay(300);
+
+      // Verify second agent was updated, first untouched
+      const updatedData = vault.getData();
+      expect(updatedData.agents['second-agent'].chains).toEqual([1, 10]);
+      expect(updatedData.agents['test-agent'].chains).toEqual([1]);
+    });
+  });
+});

--- a/packages/cli/src/tui/screens/ServicesScreen.e2e.test.tsx
+++ b/packages/cli/src/tui/screens/ServicesScreen.e2e.test.tsx
@@ -1,0 +1,578 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ServicesScreen } from './ServicesScreen.js';
+import {
+  KEYS,
+  type,
+  createTestVault,
+  waitForRender,
+} from '../test-helpers.js';
+
+const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+const MOCK_API_KEYS = [
+  { name: 'etherscan', base_url: 'https://api.etherscan.io' },
+  { name: 'polygonscan', base_url: 'https://api.polygonscan.com' },
+];
+
+const MOCK_RPC_ENDPOINTS = [
+  { name: 'sepolia', url: 'https://rpc.sepolia.org', chain_id: 11155111 },
+  { name: 'mainnet', url: 'https://mainnet.infura.io', chain_id: 1 },
+];
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof ServicesScreen>> = {}) {
+  return {
+    apiKeys: MOCK_API_KEYS,
+    rpcEndpoints: MOCK_RPC_ENDPOINTS,
+    onAddApiKey: vi.fn().mockResolvedValue(undefined),
+    onRemoveApiKey: vi.fn().mockResolvedValue(undefined),
+    onAddRpcEndpoint: vi.fn().mockResolvedValue(undefined),
+    onRemoveRpcEndpoint: vi.fn().mockResolvedValue(undefined),
+    onBack: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('ServicesScreen e2e', () => {
+  // ─── List Mode ────────────────────────────────────────────────
+
+  describe('list mode', () => {
+    it('renders API keys section with names and URLs', () => {
+      const { lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      const frame = lastFrame()!;
+      expect(frame).toContain('API Keys');
+      expect(frame).toContain('etherscan');
+      expect(frame).toContain('https://api.etherscan.io');
+      expect(frame).toContain('polygonscan');
+      expect(frame).toContain('https://api.polygonscan.com');
+    });
+
+    it('renders RPC endpoints section with names and chain IDs', () => {
+      const { lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      const frame = lastFrame()!;
+      expect(frame).toContain('RPC Endpoints');
+      expect(frame).toContain('sepolia');
+      expect(frame).toContain('chain 11155111');
+      expect(frame).toContain('mainnet');
+      expect(frame).toContain('chain 1');
+    });
+
+    it('Tab switches active section between API and RPC', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+
+      // API section active by default, first API key selected
+      expect(lastFrame()!).toMatch(/>\s.*etherscan/);
+
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+
+      // Now RPC section active, first RPC endpoint selected
+      const frame = lastFrame()!;
+      expect(frame).toMatch(/>\s.*sepolia/);
+    });
+
+    it('arrow navigation highlights different items in API section', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      // First API key selected by default
+      expect(lastFrame()!).toMatch(/>\s.*etherscan/);
+
+      await delay();
+      stdin.write(KEYS.DOWN);
+      await delay();
+
+      expect(lastFrame()!).toMatch(/>\s.*polygonscan/);
+    });
+
+    it('arrow navigation highlights different items in RPC section', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+
+      // Switch to RPC section
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      expect(lastFrame()!).toMatch(/>\s.*sepolia/);
+
+      stdin.write(KEYS.DOWN);
+      await delay();
+
+      expect(lastFrame()!).toMatch(/>\s.*mainnet/);
+    });
+
+    it('Esc calls onBack', async () => {
+      const onBack = vi.fn();
+      const { stdin } = render(<ServicesScreen {...defaultProps({ onBack })} />);
+      await delay();
+      stdin.write(KEYS.ESCAPE);
+      await delay();
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows help text', () => {
+      const { lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      const frame = lastFrame()!;
+      expect(frame).toContain('Tab switch');
+      expect(frame).toContain('a add');
+      expect(frame).toContain('d delete');
+      expect(frame).toContain('Esc back');
+    });
+
+    it('shows empty state when no API keys', () => {
+      const { lastFrame } = render(
+        <ServicesScreen {...defaultProps({ apiKeys: [] })} />,
+      );
+      expect(lastFrame()!).toContain('No API keys');
+    });
+
+    it('shows empty state when no RPC endpoints', () => {
+      const { lastFrame } = render(
+        <ServicesScreen {...defaultProps({ rpcEndpoints: [] })} />,
+      );
+      expect(lastFrame()!).toContain('No RPC endpoints');
+    });
+  });
+
+  // ─── Add API Key Flow ────────────────────────────────────────
+
+  describe('add API key flow', () => {
+    it('pressing a enters add-name mode with API key prompt', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('API key');
+      expect(frame).toContain('name');
+    });
+
+    it('empty name and Enter shows error', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('Name cannot be empty');
+    });
+
+    it('valid name proceeds to add-value (API key input)', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('API key value');
+    });
+
+    it('API key input is shown as asterisks, not raw text', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'SECRETKEY123');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('************');
+      expect(frame).not.toContain('SECRETKEY123');
+    });
+
+    it('empty API key and Enter shows error', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Enter without typing API key
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('API key cannot be empty');
+    });
+
+    it('valid API key proceeds to add-url (Base URL prompt)', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'MYAPIKEY');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Base URL');
+    });
+
+    it('complete API key add flow calls onAddApiKey with correct args', async () => {
+      const onAddApiKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <ServicesScreen {...defaultProps({ onAddApiKey })} />,
+      );
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'CG-APIKEY-123');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://api.coingecko.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(200);
+
+      expect(onAddApiKey).toHaveBeenCalledWith(
+        'coingecko',
+        'CG-APIKEY-123',
+        'https://api.coingecko.com',
+      );
+    });
+
+    it('empty URL and Enter shows error', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'coingecko');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'MYAPIKEY');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Enter without typing URL
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('URL cannot be empty');
+    });
+  });
+
+  // ─── Add RPC Endpoint Flow ───────────────────────────────────
+
+  describe('add RPC endpoint flow', () => {
+    it('Tab to RPC then a enters add-name with RPC endpoint prompt', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('a');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('RPC endpoint');
+      expect(frame).toContain('name');
+    });
+
+    it('complete RPC add flow: name -> URL -> chain ID -> calls onAddRpcEndpoint', async () => {
+      const onAddRpcEndpoint = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <ServicesScreen {...defaultProps({ onAddRpcEndpoint })} />,
+      );
+      await delay();
+      // Switch to RPC section
+      stdin.write(KEYS.TAB);
+      await delay();
+      // Enter add mode
+      stdin.write('a');
+      await delay();
+      // Type name
+      type(stdin, 'polygon');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Type URL (RPC skips add-value, goes to add-url)
+      type(stdin, 'https://polygon-rpc.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      // Type chain ID
+      type(stdin, '137');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(200);
+
+      expect(onAddRpcEndpoint).toHaveBeenCalledWith(
+        'polygon',
+        'https://polygon-rpc.com',
+        137,
+      );
+    });
+
+    it('RPC flow shows Chain ID prompt after URL', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'polygon');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://polygon-rpc.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('Chain ID');
+    });
+
+    it('invalid chain ID shows error', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'polygon');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://polygon-rpc.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'abc');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('Invalid chain ID');
+    });
+
+    it('zero chain ID shows error', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'polygon');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://polygon-rpc.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '0');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+
+      expect(lastFrame()!).toContain('Invalid chain ID');
+    });
+  });
+
+  // ─── Delete Flows ────────────────────────────────────────────
+
+  describe('delete flows', () => {
+    it('API: d shows delete confirmation with API key name', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Delete');
+      expect(frame).toContain('API key');
+      expect(frame).toContain('etherscan');
+      expect(frame).toContain('y/n');
+    });
+
+    it('API: y confirms deletion and calls onRemoveApiKey', async () => {
+      const onRemoveApiKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <ServicesScreen {...defaultProps({ onRemoveApiKey })} />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('y');
+      await waitForRender(200);
+
+      expect(onRemoveApiKey).toHaveBeenCalledWith('etherscan');
+    });
+
+    it('RPC: Tab then d shows delete confirmation with RPC endpoint name', async () => {
+      const { stdin, lastFrame } = render(<ServicesScreen {...defaultProps()} />);
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('Delete');
+      expect(frame).toContain('RPC endpoint');
+      expect(frame).toContain('sepolia');
+      expect(frame).toContain('y/n');
+    });
+
+    it('RPC: Tab then d then y calls onRemoveRpcEndpoint', async () => {
+      const onRemoveRpcEndpoint = vi.fn().mockResolvedValue(undefined);
+      const { stdin } = render(
+        <ServicesScreen {...defaultProps({ onRemoveRpcEndpoint })} />,
+      );
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('y');
+      await waitForRender(200);
+
+      expect(onRemoveRpcEndpoint).toHaveBeenCalledWith('sepolia');
+    });
+
+    it('n cancels deletion and returns to list', async () => {
+      const onRemoveApiKey = vi.fn().mockResolvedValue(undefined);
+      const { stdin, lastFrame } = render(
+        <ServicesScreen {...defaultProps({ onRemoveApiKey })} />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+      stdin.write('n');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('etherscan');
+      expect(frame).toContain('a add');
+      expect(onRemoveApiKey).not.toHaveBeenCalled();
+    });
+
+    it('d is ignored when current section list is empty', async () => {
+      const { stdin, lastFrame } = render(
+        <ServicesScreen {...defaultProps({ apiKeys: [] })} />,
+      );
+      await delay();
+      stdin.write('d');
+      await delay();
+
+      const frame = lastFrame()!;
+      expect(frame).toContain('No API keys');
+      expect(frame).not.toContain('Delete');
+    });
+  });
+
+  // ─── Real Vault Roundtrip ─────────────────────────────────────
+
+  describe('real vault roundtrip', () => {
+    let vault: Awaited<ReturnType<typeof createTestVault>>['vault'];
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await createTestVault();
+      vault = result.vault;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it('add API key via real vault callbacks and verify persistence', async () => {
+      const onAddApiKey = async (name: string, key: string, url: string) => {
+        await vault.addApiKey(name, key, url);
+      };
+
+      const { stdin } = render(
+        <ServicesScreen
+          {...defaultProps({
+            apiKeys: [],
+            rpcEndpoints: [],
+            onAddApiKey,
+          })}
+        />,
+      );
+
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'alchemy');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'ALCHEMY_SECRET_KEY');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://eth-mainnet.g.alchemy.com');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(300);
+
+      const storedApiKeys = vault.listApiKeys();
+      expect(storedApiKeys).toHaveLength(1);
+      expect(storedApiKeys[0].name).toBe('alchemy');
+      expect(storedApiKeys[0].base_url).toBe('https://eth-mainnet.g.alchemy.com');
+    });
+
+    it('add RPC endpoint via real vault callbacks and verify persistence', async () => {
+      const onAddRpcEndpoint = async (name: string, url: string, chainId: number) => {
+        await vault.addRpcEndpoint(name, url, chainId);
+      };
+
+      const { stdin } = render(
+        <ServicesScreen
+          {...defaultProps({
+            apiKeys: [],
+            rpcEndpoints: [],
+            onAddRpcEndpoint,
+          })}
+        />,
+      );
+
+      // Switch to RPC section
+      await delay();
+      stdin.write(KEYS.TAB);
+      await delay();
+      stdin.write('a');
+      await delay();
+      type(stdin, 'arbitrum');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, 'https://arb1.arbitrum.io/rpc');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await delay();
+      type(stdin, '42161');
+      await delay();
+      stdin.write(KEYS.ENTER);
+      await waitForRender(300);
+
+      const storedEndpoints = vault.listRpcEndpoints();
+      expect(storedEndpoints).toHaveLength(1);
+      expect(storedEndpoints[0].name).toBe('arbitrum');
+      expect(storedEndpoints[0].url).toBe('https://arb1.arbitrum.io/rpc');
+      expect(storedEndpoints[0].chain_id).toBe(42161);
+    });
+  });
+});

--- a/packages/cli/src/tui/test-helpers.ts
+++ b/packages/cli/src/tui/test-helpers.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MasterVault, AgentVaultManager, ChainVaultDB, AuditStore } from '@chainvault/core';
+
+export const KEYS = {
+  UP: '\x1B[A',
+  DOWN: '\x1B[B',
+  ENTER: '\r',
+  ESCAPE: '\x1B',
+  BACKSPACE: '\x7F',
+  TAB: '\t',
+} as const;
+
+export function type(stdin: { write: (s: string) => void }, text: string) {
+  for (const char of text) {
+    stdin.write(char);
+  }
+}
+
+export function press(stdin: { write: (s: string) => void }, key: keyof typeof KEYS) {
+  stdin.write(KEYS[key]);
+}
+
+const TEST_PASSWORD = 'test-password-123';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+export { TEST_PASSWORD, TEST_PRIVATE_KEY };
+
+export async function createTestVault(): Promise<{
+  dir: string;
+  vault: MasterVault;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'cv-tui-test-'));
+  await MasterVault.init(dir, TEST_PASSWORD);
+  const vault = await MasterVault.unlock(dir, TEST_PASSWORD);
+  return {
+    dir,
+    vault,
+    cleanup: async () => {
+      vault.lock();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createTestVaultWithData(): Promise<{
+  dir: string;
+  vault: MasterVault;
+  manager: AgentVaultManager;
+  cleanup: () => Promise<void>;
+}> {
+  const { dir, vault, cleanup } = await createTestVault();
+  await vault.addKey('test-wallet', TEST_PRIVATE_KEY, [1, 11155111]);
+  await vault.addApiKey('etherscan', 'TEST_KEY', 'https://api.etherscan.io');
+  await vault.addRpcEndpoint('sepolia', 'https://rpc.sepolia.org', 11155111);
+  const manager = new AgentVaultManager(dir, vault);
+  return { dir, vault, manager, cleanup };
+}
+
+export function createTestAuditStore(dir: string): AuditStore {
+  const db = new ChainVaultDB(dir);
+  return new AuditStore(db);
+}
+
+export async function waitForRender(ms = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/core/src/mcp/mcp-integration.e2e.test.ts
+++ b/packages/core/src/mcp/mcp-integration.e2e.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ChainVaultServer } from './server.js';
+import { SUPPORTED_CHAINS } from '../chain/chains.js';
+
+describe('MCP Server Integration (in-process via InMemoryTransport)', () => {
+  let client: Client;
+  let serverInstance: ChainVaultServer;
+  let clientTransport: InMemoryTransport;
+  let serverTransport: InMemoryTransport;
+
+  beforeAll(async () => {
+    serverInstance = new ChainVaultServer({ basePath: '/tmp/chainvault-mcp-test' });
+
+    [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+
+    await serverInstance.getMcpServer().connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await serverInstance.getMcpServer().close();
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool discovery
+  // -----------------------------------------------------------------------
+  describe('Tool discovery', () => {
+    it('listTools returns a non-empty array of tools', async () => {
+      const result = await client.listTools();
+      expect(result.tools.length).toBeGreaterThan(0);
+    });
+
+    it('every tool has name, description, and inputSchema', async () => {
+      const { tools } = await client.listTools();
+      for (const tool of tools) {
+        expect(tool.name).toBeDefined();
+        expect(typeof tool.name).toBe('string');
+        expect(tool.name.length).toBeGreaterThan(0);
+
+        expect(tool.description).toBeDefined();
+        expect(typeof tool.description).toBe('string');
+
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.inputSchema.type).toBe('object');
+      }
+    });
+
+    it('contains chain registry tools', async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('list_supported_chains');
+      expect(names).toContain('request_faucet');
+    });
+
+    it('contains compiler tools', async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('compile_contract');
+    });
+
+    it('contains vault tools', async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('list_chains');
+      expect(names).toContain('list_capabilities');
+      expect(names).toContain('get_agent_address');
+    });
+
+    it('contains chain tools', async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('deploy_contract');
+      expect(names).toContain('interact_contract');
+      expect(names).toContain('get_balance');
+      expect(names).toContain('get_contract_state');
+      expect(names).toContain('simulate_transaction');
+      expect(names).toContain('get_events');
+      expect(names).toContain('get_transaction');
+      expect(names).toContain('verify_contract');
+    });
+
+    it('contains proxy tools', async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('query_explorer');
+      expect(names).toContain('query_price');
+    });
+
+    it('total registered tool count matches server tracking', async () => {
+      const { tools } = await client.listTools();
+      const serverNames = serverInstance.getRegisteredToolNames();
+      expect(tools.length).toBe(serverNames.length);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list_supported_chains tool
+  // -----------------------------------------------------------------------
+  describe('list_supported_chains tool', () => {
+    it('returns all chains when called with no filter', async () => {
+      const result = await client.callTool({ name: 'list_supported_chains', arguments: {} });
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe('text');
+
+      const chains = JSON.parse(content[0].text);
+      expect(Array.isArray(chains)).toBe(true);
+      expect(chains.length).toBe(SUPPORTED_CHAINS.length);
+      expect(chains.length).toBeGreaterThanOrEqual(14);
+    });
+
+    it('filters to mainnet chains only', async () => {
+      const result = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'mainnet' },
+      });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const chains = JSON.parse(content[0].text);
+
+      expect(chains.length).toBeGreaterThan(0);
+      for (const chain of chains) {
+        expect(chain.network).toBe('mainnet');
+      }
+    });
+
+    it('filters to testnet chains only', async () => {
+      const result = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'testnet' },
+      });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const chains = JSON.parse(content[0].text);
+
+      expect(chains.length).toBeGreaterThan(0);
+      for (const chain of chains) {
+        expect(chain.network).toBe('testnet');
+      }
+    });
+
+    it('each chain entry has the expected fields', async () => {
+      const result = await client.callTool({ name: 'list_supported_chains', arguments: {} });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const chains = JSON.parse(content[0].text);
+
+      for (const chain of chains) {
+        expect(chain).toHaveProperty('chainId');
+        expect(typeof chain.chainId).toBe('number');
+
+        expect(chain).toHaveProperty('name');
+        expect(typeof chain.name).toBe('string');
+
+        expect(chain).toHaveProperty('nativeCurrency');
+        expect(typeof chain.nativeCurrency).toBe('string');
+
+        expect(chain).toHaveProperty('hasWebSocket');
+        expect(typeof chain.hasWebSocket).toBe('boolean');
+
+        expect(chain).toHaveProperty('hasFaucet');
+        expect(typeof chain.hasFaucet).toBe('boolean');
+
+        expect(chain).toHaveProperty('blockExplorer');
+      }
+    });
+
+    it('mainnet + testnet counts equal total', async () => {
+      const allResult = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: {},
+      });
+      const mainnetResult = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'mainnet' },
+      });
+      const testnetResult = await client.callTool({
+        name: 'list_supported_chains',
+        arguments: { network: 'testnet' },
+      });
+
+      const allContent = allResult.content as Array<{ type: string; text: string }>;
+      const mainnetContent = mainnetResult.content as Array<{ type: string; text: string }>;
+      const testnetContent = testnetResult.content as Array<{ type: string; text: string }>;
+
+      const allChains = JSON.parse(allContent[0].text);
+      const mainnetChains = JSON.parse(mainnetContent[0].text);
+      const testnetChains = JSON.parse(testnetContent[0].text);
+
+      expect(mainnetChains.length + testnetChains.length).toBe(allChains.length);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // request_faucet tool
+  // -----------------------------------------------------------------------
+  describe('request_faucet tool', () => {
+    const TEST_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+    it('returns result with correct chainId for a testnet chain', async () => {
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 11155111, address: TEST_ADDRESS },
+      });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+
+      expect(parsed.chainId).toBe(11155111);
+      expect(parsed.chainName).toBe('Sepolia');
+    });
+
+    it('returns success=false for a mainnet chain', async () => {
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 1, address: TEST_ADDRESS },
+      });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.message.toLowerCase()).toContain('mainnet');
+    });
+
+    it('returns success=false for an unknown chain', async () => {
+      const result = await client.callTool({
+        name: 'request_faucet',
+        arguments: { chain_id: 999999, address: TEST_ADDRESS },
+      });
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0].text);
+
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stub tools return without error
+  // -----------------------------------------------------------------------
+  describe('Stub tools return without error', () => {
+    it('get_balance returns content', async () => {
+      const result = await client.callTool({
+        name: 'get_balance',
+        arguments: { chain_id: 1, address: '0x0000000000000000000000000000000000000000' },
+      });
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('list_chains returns content', async () => {
+      const result = await client.callTool({
+        name: 'list_chains',
+        arguments: {},
+      });
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('simulate_transaction returns content', async () => {
+      const result = await client.callTool({
+        name: 'simulate_transaction',
+        arguments: {
+          chain_id: 1,
+          address: '0x0000000000000000000000000000000000000000',
+          abi: '[]',
+          function_name: 'test',
+        },
+      });
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('list_capabilities returns content', async () => {
+      const result = await client.callTool({
+        name: 'list_capabilities',
+        arguments: {},
+      });
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('query_explorer returns content', async () => {
+      const result = await client.callTool({
+        name: 'query_explorer',
+        arguments: {
+          chain_id: 1,
+          module: 'contract',
+          action: 'getabi',
+        },
+      });
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+    });
+  });
+});

--- a/tests/agent-e2e/HelloToken.sol
+++ b/tests/agent-e2e/HelloToken.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract HelloToken {
+    string public name = "HelloToken";
+    string public symbol = "HELLO";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(uint256 _supply) {
+        totalSupply = _supply * 10 ** decimals;
+        balanceOf[msg.sender] = totalSupply;
+        emit Transfer(address(0), msg.sender, totalSupply);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "Insufficient balance");
+        require(allowance[from][msg.sender] >= amount, "Insufficient allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}

--- a/tests/agent-e2e/chain-discovery.ts
+++ b/tests/agent-e2e/chain-discovery.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent E2E Test: Chain Discovery via ChainVault MCP
+ *
+ * Uses the Claude Code SDK to ask Claude to discover available testnet
+ * chains and faucets through the ChainVault MCP server's
+ * list_supported_chains and request_faucet tools.
+ *
+ * Prerequisites:
+ *   - ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN env var set
+ *   - CLI built: npm run build
+ *
+ * Run:
+ *   npx tsx tests/agent-e2e/chain-discovery.ts
+ */
+
+import { query } from '@anthropic-ai/claude-code';
+
+// ---------------------------------------------------------------------------
+// Prerequisite checks
+// ---------------------------------------------------------------------------
+
+const hasApiKey = Boolean(
+  process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN,
+);
+
+if (!hasApiKey) {
+  console.log(
+    'SKIP: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN to run this test.',
+  );
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Configure Claude SDK with ChainVault MCP server
+// ---------------------------------------------------------------------------
+
+const prompt =
+  'What testnet chains are available? Which have faucets? Use the list_supported_chains tool to find out.';
+
+let listChainsToolUsed = false;
+let faucetToolUsed = false;
+let resultText = '';
+
+console.log('--- chain-discovery e2e test ---');
+console.log('Sending prompt to Claude with ChainVault MCP server...\n');
+
+try {
+  const conversation = query({
+    prompt,
+    options: {
+      maxTurns: 3,
+      allowedTools: [
+        'mcp__chainvault__list_supported_chains',
+        'mcp__chainvault__request_faucet',
+      ],
+      mcpServers: {
+        chainvault: {
+          type: 'stdio' as const,
+          command: 'node',
+          args: ['./packages/cli/dist/index.js', 'serve'],
+        },
+      },
+      permissionMode: 'acceptEdits' as const,
+    },
+  });
+
+  for await (const message of conversation) {
+    // Check for assistant messages containing tool use
+    if (message.type === 'assistant') {
+      for (const block of message.message.content) {
+        if (block.type === 'tool_use') {
+          if (block.name === 'mcp__chainvault__list_supported_chains') {
+            listChainsToolUsed = true;
+            console.log('  [tool_use] list_supported_chains called with input:', JSON.stringify(block.input));
+          }
+          if (block.name === 'mcp__chainvault__request_faucet') {
+            faucetToolUsed = true;
+            console.log('  [tool_use] request_faucet called with input:', JSON.stringify(block.input));
+          }
+        }
+        if (block.type === 'text') {
+          resultText += block.text;
+        }
+      }
+    }
+
+    // Check for result messages
+    if (message.type === 'result') {
+      for (const block of message.message.content) {
+        if (block.type === 'text') {
+          resultText += block.text;
+        }
+      }
+    }
+  }
+} catch (err) {
+  console.error('ERROR:', err);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Report results
+// ---------------------------------------------------------------------------
+
+console.log('\n--- Results ---');
+console.log('list_supported_chains tool used:', listChainsToolUsed);
+console.log('request_faucet tool used:', faucetToolUsed);
+
+if (listChainsToolUsed) {
+  console.log('\nPASS: Claude used the list_supported_chains MCP tool.');
+} else {
+  console.log('\nFAIL: Claude did NOT use the list_supported_chains MCP tool.');
+  console.log('Response text (truncated):', resultText.slice(0, 500));
+  process.exit(1);
+}

--- a/tests/agent-e2e/claude-code.d.ts
+++ b/tests/agent-e2e/claude-code.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Minimal type declarations for @anthropic-ai/claude-code SDK.
+ *
+ * The package ships as a bundled CLI without exported .d.ts files.
+ * These declarations cover only the subset used by the e2e test scripts.
+ */
+declare module '@anthropic-ai/claude-code' {
+  export interface StdioMcpServer {
+    type: 'stdio';
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }
+
+  export interface QueryOptions {
+    maxTurns?: number;
+    allowedTools?: string[];
+    mcpServers?: Record<string, StdioMcpServer>;
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions';
+    systemPrompt?: string;
+    cwd?: string;
+  }
+
+  export interface TextBlock {
+    type: 'text';
+    text: string;
+  }
+
+  export interface ToolUseBlock {
+    type: 'tool_use';
+    id: string;
+    name: string;
+    input: unknown;
+  }
+
+  export type ContentBlock = TextBlock | ToolUseBlock;
+
+  export interface MessagePayload {
+    content: ContentBlock[];
+  }
+
+  /**
+   * Messages streamed from the SDK. The `type` field discriminates between
+   * assistant turns, final results, and other lifecycle events.
+   */
+  export interface SDKMessage {
+    type: string;
+    message: MessagePayload;
+    [key: string]: unknown;
+  }
+
+  export function query(params: {
+    prompt: string;
+    options?: QueryOptions;
+  }): AsyncIterable<SDKMessage>;
+}

--- a/tests/agent-e2e/compile-token.ts
+++ b/tests/agent-e2e/compile-token.ts
@@ -1,0 +1,121 @@
+/**
+ * Agent E2E Test: Compile HelloToken via ChainVault MCP
+ *
+ * Uses the Claude Code SDK to ask Claude to compile the HelloToken.sol
+ * contract through the ChainVault MCP server's compile_contract tool.
+ *
+ * Prerequisites:
+ *   - ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN env var set
+ *   - CLI built: npm run build
+ *
+ * Run:
+ *   npx tsx tests/agent-e2e/compile-token.ts
+ */
+
+import { query } from '@anthropic-ai/claude-code';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Prerequisite checks
+// ---------------------------------------------------------------------------
+
+const hasApiKey = Boolean(
+  process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN,
+);
+
+if (!hasApiKey) {
+  console.log(
+    'SKIP: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN to run this test.',
+  );
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Read the Solidity source
+// ---------------------------------------------------------------------------
+
+const solPath = resolve(__dirname, 'HelloToken.sol');
+const solSource = readFileSync(solPath, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Configure Claude SDK with ChainVault MCP server
+// ---------------------------------------------------------------------------
+
+const prompt = [
+  'I have a Solidity contract source below. Please compile it using the compile_contract tool.',
+  'Use compiler version "0.8.20" and contract name "HelloToken".',
+  '',
+  '```solidity',
+  solSource,
+  '```',
+].join('\n');
+
+let compileToolUsed = false;
+let resultText = '';
+
+console.log('--- compile-token e2e test ---');
+console.log('Sending prompt to Claude with ChainVault MCP server...\n');
+
+try {
+  const conversation = query({
+    prompt,
+    options: {
+      maxTurns: 3,
+      allowedTools: ['mcp__chainvault__compile_contract'],
+      mcpServers: {
+        chainvault: {
+          type: 'stdio' as const,
+          command: 'node',
+          args: ['./packages/cli/dist/index.js', 'serve'],
+        },
+      },
+      permissionMode: 'acceptEdits' as const,
+    },
+  });
+
+  for await (const message of conversation) {
+    // Check for assistant messages containing tool use
+    if (message.type === 'assistant') {
+      for (const block of message.message.content) {
+        if (block.type === 'tool_use' && block.name === 'mcp__chainvault__compile_contract') {
+          compileToolUsed = true;
+          console.log('  [tool_use] compile_contract called with input:', JSON.stringify(block.input));
+        }
+        if (block.type === 'text') {
+          resultText += block.text;
+        }
+      }
+    }
+
+    // Check for tool results
+    if (message.type === 'result') {
+      for (const block of message.message.content) {
+        if (block.type === 'text') {
+          resultText += block.text;
+        }
+      }
+    }
+  }
+} catch (err) {
+  console.error('ERROR:', err);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Report results
+// ---------------------------------------------------------------------------
+
+console.log('\n--- Results ---');
+console.log('compile_contract tool used:', compileToolUsed);
+
+if (compileToolUsed) {
+  console.log('\nPASS: Claude used the compile_contract MCP tool.');
+} else {
+  console.log('\nFAIL: Claude did NOT use the compile_contract MCP tool.');
+  console.log('Response text (truncated):', resultText.slice(0, 500));
+  process.exit(1);
+}

--- a/tests/agent-e2e/package.json
+++ b/tests/agent-e2e/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/agent-e2e/tsconfig.json
+++ b/tests/agent-e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,11 +9,11 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ['packages/*/src/**/*.test.ts'],
+    include: ['packages/*/src/**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       include: ['packages/*/src/**/*.ts'],
-      exclude: ['**/*.test.ts', '**/*.d.ts'],
+      exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.d.ts'],
     },
   },
 });


### PR DESCRIPTION
## Summary

- **EVM chain registry** with 14 chains from publicnode.com (WebSocket-first transport, HTTP fallback)
- **Faucet support** for testnets (programmatic API + browser URL fallback)
- **427 tests** across 33 files (up from 243), all passing, zero type errors
- **Claude SDK agent scripts** for real AI-driven MCP tool testing

### New test coverage

| Category | Tests | Description |
|----------|-------|-------------|
| Chain e2e (real RPCs) | 75 | Multi-chain connectivity, contract reads, events, gas, simulation |
| PasswordPrompt | 11 | Dual-mode auth, masking, validation |
| MainMenu | 10 | Navigation, wrapping, screen selections |
| KeysScreen | 26 | Add/delete flows, real vault roundtrip |
| AgentsScreen | 25 | Create/revoke, vault key display, real vault |
| ServicesScreen | 30 | API/RPC sections, Tab switching, add/delete |
| LogsScreen | 14 | Filter cycling, scroll, pagination, real AuditStore |
| RulesScreen | 23 | Edit chains/types/limits, validation, real vault |
| Dashboard | 10 | Status display, activity indicators |
| App journey | 14 | Unlock → navigate → mutate → verify |
| MCP integration | 21 | Tool discovery, chain registry, faucet via InMemoryTransport |
| Claude SDK scripts | 2 | compile-token.ts, chain-discovery.ts |

### Chain registry
- 14 EVM chains (7 mainnets + 7 testnets) with publicnode.com RPCs
- WebSocket-first `fallback()` transport via viem
- `EvmAdapter.fromChainId()` factory, `buildTransport()`, `getChainInfo()`
- `list_supported_chains` and `request_faucet` MCP tools
- Bugs found and fixed: wrong WETH address, Holesky unsupported, Polygon WMATIC→WPOL rename

## Test plan
- [x] `npx vitest run` — 427/427 passing
- [x] `npx tsc --noEmit` — zero errors
- [x] All TUI screens tested with `ink-testing-library` against real vault operations
- [x] MCP tools tested via `InMemoryTransport` client
- [x] Chain e2e tests hit real publicnode.com RPCs
- [ ] Claude SDK scripts require `ANTHROPIC_API_KEY` — run manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)