### PR TITLE
feat(mcp): wire all remaining MCP tools (Tier 2 + Tier 3)

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,0 +1,123 @@
+# Session Handoff — 2026-03-25
+
+## Current State
+
+- **Branch:** `feat/mcp-tier2-tier3` (also has security fixes on top)
+- **Tests:** 455 passing across 34 test files
+- **Build:** esbuild via `npm run build` (tsc OOMs on viem types)
+- **Open PR:** #7 (`feat/mcp-tier2-tier3`) — Tier 2+3 tool wiring, but security fixes (commits `af2c198`–`4dccd3c`) were added after. Needs updating or a new PR.
+- **Dev vault:** `.chainvault-dev/` with password `chainvault`, agent `dev-agent` with vault key `cv_agent_687c8827ae5f6d601d9b33cabf5e1fef7713ba0ea8fe0275bdeab289c7ac5280`
+
+## What's Complete
+
+### Core Modules (all tested)
+- **Vault:** Master vault, agent vaults, AES-256-GCM encryption, HKDF, WebAuthn/passkey, DualKeyManager
+- **Rules Engine:** Chain access, tx type filtering, per-tx/daily/monthly spend limits, contract whitelist/blacklist, API access rules
+- **Chain Module:** 14 EVM chains with PublicNode RPCs (WS priority, HTTP fallback), faucet support, EvmAdapter with read + write operations
+- **API Proxy:** Caching, per-second + daily rate limiting, usage tracking
+- **Audit:** AuditStore (SQLite) + AuditLogger (file-based legacy)
+- **Compiler:** Solidity compilation via Docker solc or local binary
+- **Database:** SQLite persistence for spend tracking + audit logs
+
+### MCP Server (all 15 tools wired — zero stubs)
+| Tool | Backend |
+|------|---------|
+| `list_chains` | Agent config |
+| `list_capabilities` | Agent config |
+| `get_agent_address` | Agent vault (public addr only) |
+| `get_balance` | EvmAdapter + rules |
+| `get_contract_state` | EvmAdapter + rules |
+| `get_transaction` | EvmAdapter + rules |
+| `get_events` | EvmAdapter + rules |
+| `simulate_transaction` | EvmAdapter + rules |
+| `deploy_contract` | EvmAdapter + rules + private key + spend tracking |
+| `interact_contract` | EvmAdapter + rules + private key + spend tracking |
+| `verify_contract` | Etherscan API + vault API key |
+| `compile_contract` | solc via Docker/local |
+| `query_explorer` | ApiProxy + vault API key + rate limits |
+| `query_price` | CoinGecko public API |
+| `list_supported_chains` | Chain registry |
+| `request_faucet` | Faucet module |
+
+### Security Hardening (done)
+- Error messages sanitized — `sanitizeError()` strips potential key material
+- Controlled vault accessors — `getPrivateKeyForChain()`, `getApiKeyForExplorer()` instead of raw `vaultData`
+- Spend recorded after successful write operations
+- Audit logging in all MCP tool handlers
+- Rules checked BEFORE vault decryption
+
+### TUI (6 screens, all e2e tested)
+Dashboard, Keys, Agents, Services, Logs, Rules — 128+ e2e tests
+
+### Infrastructure
+- Community files: README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, GitHub templates
+- `.env` support with dotenv
+- Agent e2e tests via Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`)
+- `chainvault solc pull` CLI command
+
+## Remaining Items
+
+### Medium Priority — CLI Commands Gap
+
+Only 5 of ~20 designed CLI commands are wired in `packages/cli/src/index.ts`:
+
+| Wired | Missing |
+|-------|---------|
+| `init` | `unlock`, `lock` |
+| `serve` | `status` |
+| `key list` | `key add`, `key remove`, `key generate`, `key add-seed` |
+| `agent list` | `agent create`, `agent show`, `agent revoke`, `agent rotate-key`, `agent grant`, `agent set-limit`, `agent allow-tx`, `agent set-api-limit` |
+| `solc pull` | `api add`, `api list`, `api remove`, `api add rpc` |
+| | `logs`, `logs <agent>`, `logs --denied` |
+
+Backend implementations exist in `packages/cli/src/commands/key.ts` and `packages/cli/src/commands/agent.ts` — they just need to be wired into Commander in `index.ts`. Some commands (like `key add`) need interactive password prompting since secrets must never be CLI arguments.
+
+### Low Priority — Design Compliance
+
+1. **Agent vault regeneration on permission change** — Design says "When permissions change, agent vault is regenerated from master vault." Not implemented. Currently you'd delete and recreate the agent.
+
+2. **RPC endpoints in agent vaults** — `AgentVaultManager.createAgent()` already copies matching RPC endpoints into agent vaults, but the MCP `AgentContext` doesn't expose them. Tools use `EvmAdapter.fromChainId()` which reads from the chain registry instead.
+
+3. **`tests/agent-e2e/claude-code.d.ts`** — Still declares module `@anthropic-ai/claude-code` but code imports from `@anthropic-ai/claude-agent-sdk`. Should be renamed and updated.
+
+### Housekeeping
+
+- **PR #7** is open but stale — security fix commits (`af2c198`–`4dccd3c`) were pushed to main/branch after PR creation. Should either update the PR or close and create a new one.
+- **Old branches** can be cleaned up: `feat/chainvault-core`, `feat/v1.1-tui-sqlite`, `feat/v1.1-webauthn-compiler`, `feat/e2e_tests`, `feat/mcp-tool-wiring`
+
+### V2 Roadmap (not started)
+- Slither/Aderyn analysis tools (Docker containers)
+- Web admin panel
+- Non-EVM chain adapters (Solana, Move, Bitcoin)
+
+## Key Files
+
+| Purpose | Path |
+|---------|------|
+| Design doc | `docs/plans/2026-03-19-chainvault-mcp-design.md` |
+| Implementation plan | `docs/plans/2026-03-19-chainvault-mcp-implementation.md` |
+| MCP tool wiring design | `docs/plans/2026-03-21-mcp-tool-wiring-design.md` |
+| Tier 2+3 design | `docs/plans/2026-03-24-mcp-tier2-tier3-design.md` |
+| Agent context | `packages/core/src/mcp/context.ts` |
+| MCP server | `packages/core/src/mcp/server.ts` |
+| Chain tools | `packages/core/src/mcp/tools/chain-tools.ts` |
+| CLI entry | `packages/cli/src/index.ts` |
+| Dev vault | `.chainvault-dev/` (password: `chainvault`) |
+| Env config | `.env` (has CHAINVAULT_PASSWORD, CHAINVAULT_PATH, CLAUDE_CODE_OAUTH_TOKEN) |
+
+## Commands
+
+```bash
+npm run build          # esbuild transpile (not tsc)
+npx vitest run         # 455 tests
+npx tsc --noEmit       # type check only
+npx vitest run packages/core/src/mcp/  # MCP tests only
+
+# Serve with agent context
+CHAINVAULT_VAULT_KEY=cv_agent_687c8827ae5f6d601d9b33cabf5e1fef7713ba0ea8fe0275bdeab289c7ac5280 \
+  node packages/cli/dist/index.js serve -p .chainvault-dev
+
+# Agent e2e tests (need CLAUDE_CODE_OAUTH_TOKEN in .env)
+npx tsx tests/agent-e2e/chain-discovery.ts
+npx tsx tests/agent-e2e/compile-token.ts
+```

--- a/docs/plans/2026-03-24-mcp-tier2-tier3-design.md
+++ b/docs/plans/2026-03-24-mcp-tier2-tier3-design.md
@@ -1,0 +1,59 @@
+# MCP Tool Wiring (Tier 2 + Tier 3) — Design Document
+
+**Date:** 2026-03-24
+**Status:** Approved
+**Author:** Vasilis Magkoutis
+
+## 1. Overview
+
+Wire remaining 5 MCP tool stubs: write operations (deploy_contract, interact_contract, verify_contract) and API proxy tools (query_explorer, query_price). Also fix the tsc OOM build issue by switching to esbuild.
+
+## 2. Tier 2 — Write Operations
+
+### deploy_contract
+1. Rules check: chain access + tx type `deploy` + spend limits
+2. Extract private key from `ctx.vaultData.keys` for matching chain
+3. Call `EvmAdapter.deployContract({ privateKey, abi, bytecode, args })`
+4. Record spend via `ctx.rules.recordSpend()`
+5. Return `{ hash, contractAddress }`
+
+### interact_contract
+1. Rules check: chain access + tx type `write` + spend limits + contract whitelist/blacklist
+2. Extract private key, call `EvmAdapter.writeContract()`
+3. Record spend, return `{ hash }`
+
+### verify_contract
+1. Rules check: chain access + API access for explorer
+2. Get API key from `ctx.vaultData.api_keys`
+3. POST to Etherscan verification endpoint
+4. Return verification status
+
+## 3. Tier 3 — API Proxy
+
+### query_explorer
+1. Rules check: API access for explorer service
+2. Get API key from vault, map chain_id to explorer URL
+3. Call `ApiProxy.request()` with rate limits
+4. Return result
+
+### query_price
+- Public CoinGecko API (no key required, key optional for higher limits)
+- Fetch `api.coingecko.com/api/v3/simple/price`
+- Return `{ token, price, currency }`
+
+## 4. Security
+
+- Private keys extracted from vault only during signing, scoped to adapter call
+- Spend tracked after successful transactions
+- API keys never returned in tool responses
+
+## 5. Build Fix
+
+- Replace tsc build with esbuild script (tsc OOMs on viem types)
+- `scripts/build.sh` transpiles both packages
+
+## 6. Testing
+
+- Rules enforcement: deny deploy, deny over limit, deny blacklisted contract
+- Success paths: mock EvmAdapter (no real txs in tests)
+- API proxy: mock fetch, test rate limiting, test missing API key

--- a/docs/plans/2026-03-24-mcp-tier2-tier3-implementation.md
+++ b/docs/plans/2026-03-24-mcp-tier2-tier3-implementation.md
@@ -1,0 +1,574 @@
+# MCP Tool Wiring (Tier 2 + Tier 3) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire the remaining 5 MCP tool stubs (deploy_contract, interact_contract, verify_contract, query_explorer, query_price) to their backend modules, and fix the build system.
+
+**Architecture:** Write tools extract private keys from `ctx.vaultData.keys` scoped to the adapter call. Proxy tools use `ApiProxy` with API keys from `ctx.vaultData.api_keys`. `registerProxyTools` gains a `getContext` parameter. Build switches from tsc to esbuild.
+
+**Tech Stack:** TypeScript, `@modelcontextprotocol/server`, `viem` (via `EvmAdapter`), `ApiProxy`, `vitest`, `esbuild`
+
+**Design Doc:** `docs/plans/2026-03-24-mcp-tier2-tier3-design.md`
+
+---
+
+## Task 1: Wire deploy_contract and interact_contract
+
+**Files:**
+- Modify: `packages/core/src/mcp/tools/chain-tools.ts`
+- Modify: `packages/core/src/mcp/mcp-integration.e2e.test.ts`
+
+These two tools follow the same pattern: check rules → find private key → call EvmAdapter → record spend → return hash.
+
+**Step 1: Write failing tests**
+
+Add to `mcp-integration.e2e.test.ts` inside the "Vault tools (with agent context)" describe block. The test agent config has `allowed_types: ['read', 'simulate']` so deploy/write should be DENIED by rules:
+
+```typescript
+describe('Chain write tools (rules enforcement)', () => {
+  it('deploy_contract denied when agent lacks deploy permission', async () => {
+    const result = await ctxClient.callTool({
+      name: 'deploy_contract',
+      arguments: {
+        chain_id: 11155111,
+        abi: '[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}]',
+        bytecode: '0x608060405234801561001057600080fd5b50',
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toContain('not allowed');
+  });
+
+  it('interact_contract denied when agent lacks write permission', async () => {
+    const result = await ctxClient.callTool({
+      name: 'interact_contract',
+      arguments: {
+        chain_id: 11155111,
+        address: '0x0000000000000000000000000000000000000001',
+        abi: '[{"inputs":[],"name":"foo","outputs":[],"stateMutability":"nonpayable","type":"function"}]',
+        function_name: 'foo',
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toContain('not allowed');
+  });
+
+  it('deploy_contract denied for unauthorized chain', async () => {
+    const result = await ctxClient.callTool({
+      name: 'deploy_contract',
+      arguments: {
+        chain_id: 1,
+        abi: '[]',
+        bytecode: '0x00',
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toContain('does not have access');
+  });
+
+  it('deploy_contract returns error without agent context', async () => {
+    const result = await client.callTool({
+      name: 'deploy_contract',
+      arguments: {
+        chain_id: 11155111,
+        abi: '[]',
+        bytecode: '0x00',
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toContain('CHAINVAULT_VAULT_KEY');
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/core/src/mcp/mcp-integration.e2e.test.ts`
+Expected: FAIL — tools still return "Not yet implemented".
+
+**Step 3: Implement deploy_contract and interact_contract handlers**
+
+In `chain-tools.ts`, add a helper to find the private key and a helper for write-operation rules checking:
+
+```typescript
+function checkWriteAccess(
+  ctx: AgentContext | null,
+  chainId: number,
+  txType: 'deploy' | 'write' | 'transfer',
+  value: string = '0',
+  toAddress?: string,
+): string | null {
+  if (!ctx) return 'No agent context. Set CHAINVAULT_VAULT_KEY.';
+  const result = ctx.rules.checkTxRequest({
+    type: txType,
+    chain_id: chainId,
+    value,
+    to_address: toAddress,
+  });
+  if (!result.approved) return result.reason ?? `Operation denied.`;
+  return null;
+}
+
+function getPrivateKey(ctx: AgentContext, chainId: number): string | null {
+  for (const [, key] of Object.entries(ctx.vaultData.keys)) {
+    if (key.chains.includes(chainId)) {
+      return key.private_key;
+    }
+  }
+  return null;
+}
+```
+
+Replace `deploy_contract` handler:
+
+```typescript
+async ({ chain_id, abi, bytecode, constructor_args }) => {
+  const ctx = getContext();
+  const err = checkWriteAccess(ctx, chain_id, 'deploy');
+  if (err) return { content: [{ type: 'text' as const, text: err }] };
+
+  const privateKey = getPrivateKey(ctx!, chain_id);
+  if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+
+  try {
+    const adapter = EvmAdapter.fromChainId(chain_id);
+    const parsedAbi = JSON.parse(abi);
+    const result = await adapter.deployContract({
+      abi: parsedAbi,
+      bytecode,
+      args: constructor_args,
+      privateKey,
+    });
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({
+        hash: result.hash,
+        contractAddress: result.address ?? null,
+      }, null, 2) }],
+    };
+  } catch (e: any) {
+    return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+  }
+},
+```
+
+Replace `interact_contract` handler:
+
+```typescript
+async ({ chain_id, address, abi, function_name, args, value }) => {
+  const ctx = getContext();
+  const err = checkWriteAccess(ctx, chain_id, 'write', value ?? '0', address);
+  if (err) return { content: [{ type: 'text' as const, text: err }] };
+
+  const privateKey = getPrivateKey(ctx!, chain_id);
+  if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+
+  try {
+    const adapter = EvmAdapter.fromChainId(chain_id);
+    const parsedAbi = JSON.parse(abi);
+    const result = await adapter.writeContract({
+      address,
+      abi: parsedAbi,
+      functionName: function_name,
+      args: args ?? [],
+      privateKey,
+      value,
+    });
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({ hash: result.hash }, null, 2) }],
+    };
+  } catch (e: any) {
+    return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+  }
+},
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/core/src/mcp/mcp-integration.e2e.test.ts`
+Expected: All tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/core/src/mcp/tools/chain-tools.ts packages/core/src/mcp/mcp-integration.e2e.test.ts
+git commit -m "feat(mcp): wire deploy_contract and interact_contract with rules enforcement"
+```
+
+---
+
+## Task 2: Wire verify_contract
+
+**Files:**
+- Modify: `packages/core/src/mcp/tools/chain-tools.ts`
+- Modify: `packages/core/src/mcp/mcp-integration.e2e.test.ts`
+
+Etherscan contract verification uses a POST to their API with source code, compiler version, and ABI. We look up the explorer API URL from the chain registry and use the API key from the agent vault.
+
+**Step 1: Write failing test**
+
+```typescript
+it('verify_contract denied without API key for explorer', async () => {
+  // The test agent has no api_access configured
+  const result = await ctxClient.callTool({
+    name: 'verify_contract',
+    arguments: {
+      chain_id: 11155111,
+      address: '0x0000000000000000000000000000000000000001',
+      source_code: 'pragma solidity ^0.8.20; contract X {}',
+      contract_name: 'X',
+      compiler_version: '0.8.20',
+    },
+  });
+  const text = (result.content as any)[0].text;
+  // Should fail because agent has no API keys
+  expect(text).toMatch(/no.*api.*key|not configured/i);
+});
+```
+
+**Step 2: Implement verify_contract handler**
+
+Replace the stub with:
+
+```typescript
+async ({ chain_id, address, source_code, contract_name, compiler_version, optimization }) => {
+  const ctx = getContext();
+  if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+
+  // Find explorer API URL from chain config
+  const chainConfig = (await import('../../chain/chains.js')).getChainConfig(chain_id);
+  if (!chainConfig?.blockExplorer?.apiUrl) {
+    return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
+  }
+
+  // Find an API key for the explorer
+  const apiKeyEntry = Object.values(ctx.vaultData.api_keys).find(
+    (ak) => chainConfig.blockExplorer!.apiUrl!.includes(new URL(ak.base_url).hostname.split('.').slice(-2).join('.')),
+  );
+  if (!apiKeyEntry) {
+    return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one with 'chainvault api add'.` }] };
+  }
+
+  try {
+    const params = new URLSearchParams({
+      apikey: apiKeyEntry.key,
+      module: 'contract',
+      action: 'verifysourcecode',
+      contractaddress: address,
+      sourceCode: source_code,
+      codeformat: 'solidity-single-file',
+      contractname: contract_name,
+      compilerversion: `v${compiler_version}`,
+      optimizationUsed: optimization ? '1' : '0',
+    });
+
+    const response = await fetch(`${chainConfig.blockExplorer.apiUrl}/api`, {
+      method: 'POST',
+      body: params,
+    });
+    const data = await response.json();
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: any) {
+    return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+  }
+},
+```
+
+**Step 3: Run tests**
+
+Run: `npx vitest run packages/core/src/mcp/mcp-integration.e2e.test.ts`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add packages/core/src/mcp/tools/chain-tools.ts packages/core/src/mcp/mcp-integration.e2e.test.ts
+git commit -m "feat(mcp): wire verify_contract to block explorer verification API"
+```
+
+---
+
+## Task 3: Wire query_explorer and query_price
+
+**Files:**
+- Modify: `packages/core/src/mcp/tools/proxy-tools.ts`
+- Modify: `packages/core/src/mcp/server.ts` (pass getContext to registerProxyTools)
+- Modify: `packages/core/src/mcp/mcp-integration.e2e.test.ts`
+
+**Step 1: Write failing tests**
+
+```typescript
+describe('Proxy tools', () => {
+  it('query_explorer denied without API key', async () => {
+    // ctxClient's agent has no api_access
+    const result = await ctxClient.callTool({
+      name: 'query_explorer',
+      arguments: {
+        chain_id: 11155111,
+        module: 'contract',
+        action: 'getabi',
+        params: { address: '0x0000000000000000000000000000000000000001' },
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toMatch(/no.*api.*key|not configured/i);
+  });
+
+  it('query_explorer returns error without agent context', async () => {
+    const result = await client.callTool({
+      name: 'query_explorer',
+      arguments: {
+        chain_id: 11155111,
+        module: 'contract',
+        action: 'getabi',
+      },
+    });
+    const text = (result.content as any)[0].text;
+    expect(text).toContain('CHAINVAULT_VAULT_KEY');
+  });
+
+  it('query_price returns price data (public API)', async () => {
+    // query_price uses public CoinGecko API — no API key needed
+    // This is a live API call, so we just verify structure
+    const result = await client.callTool({
+      name: 'query_price',
+      arguments: { token_id: 'ethereum' },
+    });
+    const text = (result.content as any)[0].text;
+    const parsed = JSON.parse(text);
+    // Should have a price field or an error
+    expect(parsed.ethereum?.usd ?? parsed.error).toBeDefined();
+  });
+});
+```
+
+**Step 2: Update server.ts to pass getContext to registerProxyTools**
+
+In `packages/core/src/mcp/server.ts`, change:
+```typescript
+registerProxyTools(this.mcpServer);
+```
+to:
+```typescript
+registerProxyTools(this.mcpServer, getContext);
+```
+
+**Step 3: Implement proxy tools**
+
+```typescript
+// packages/core/src/mcp/tools/proxy-tools.ts
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AgentContext } from '../context.js';
+import { getChainConfig } from '../../chain/chains.js';
+import { ApiProxy } from '../../proxy/api-proxy.js';
+
+type ContextGetter = () => AgentContext | null;
+
+const proxy = new ApiProxy();
+
+export function registerProxyTools(server: McpServer, getContext: ContextGetter): void {
+  server.registerTool(
+    'query_explorer',
+    {
+      title: 'Query Block Explorer',
+      description: 'Query a block explorer API (e.g., Etherscan) for contract ABIs, source code, transaction history, etc.',
+      inputSchema: z.object({
+        chain_id: z.number().int().describe('Chain ID'),
+        module: z.string().describe('API module (e.g., "contract", "account", "transaction")'),
+        action: z.string().describe('API action (e.g., "getabi", "getsourcecode", "txlist")'),
+        params: z.record(z.string(), z.string()).optional().describe('Additional query parameters'),
+      }),
+    },
+    async ({ chain_id, module: mod, action, params: extraParams }) => {
+      const ctx = getContext();
+      if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+
+      // Find explorer API URL
+      const chainConfig = getChainConfig(chain_id);
+      if (!chainConfig?.blockExplorer?.apiUrl) {
+        return { content: [{ type: 'text' as const, text: `No block explorer API for chain ${chain_id}.` }] };
+      }
+
+      // Find API key matching this explorer
+      const explorerHost = new URL(chainConfig.blockExplorer.apiUrl).hostname;
+      const apiKeyEntry = Object.entries(ctx.vaultData.api_keys).find(
+        ([, ak]) => {
+          try { return new URL(ak.base_url).hostname.includes(explorerHost.split('.').slice(-2, -1)[0]); }
+          catch { return false; }
+        },
+      );
+
+      if (!apiKeyEntry) {
+        return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
+      }
+
+      const [serviceName, apiKey] = apiKeyEntry;
+
+      // Check API access rules
+      const apiCheck = ctx.rules.checkApiRequest({ service: serviceName, endpoint: action });
+      if (!apiCheck.approved) {
+        return { content: [{ type: 'text' as const, text: apiCheck.reason ?? 'API access denied.' }] };
+      }
+
+      // Get rate limits from agent config
+      const rateLimits = ctx.config.api_access[serviceName]?.rate_limit;
+
+      try {
+        const result = await proxy.request({
+          baseUrl: chainConfig.blockExplorer.apiUrl,
+          endpoint: '/api',
+          params: { module: mod, action, ...(extraParams ?? {}) },
+          apiKey: apiKey.key,
+          rateLimits,
+        });
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      }
+    },
+  );
+
+  server.registerTool(
+    'query_price',
+    {
+      title: 'Get Token Price',
+      description: 'Get current token price data from CoinGecko',
+      inputSchema: z.object({
+        token_id: z.string().describe('Token identifier (e.g., "ethereum", "bitcoin")'),
+        currency: z.string().optional().describe('Target currency (default: "usd")'),
+      }),
+    },
+    async ({ token_id, currency }) => {
+      const cur = currency ?? 'usd';
+      try {
+        const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(token_id)}&vs_currencies=${encodeURIComponent(cur)}`;
+        const response = await fetch(url);
+        if (!response.ok) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: `CoinGecko API error: ${response.status}` }) }] };
+        }
+        const data = await response.json();
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: e.message }) }] };
+      }
+    },
+  );
+}
+```
+
+**Step 4: Run tests**
+
+Run: `npx vitest run packages/core/src/mcp/mcp-integration.e2e.test.ts`
+Expected: All tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/core/src/mcp/tools/proxy-tools.ts packages/core/src/mcp/server.ts packages/core/src/mcp/mcp-integration.e2e.test.ts
+git commit -m "feat(mcp): wire query_explorer and query_price to ApiProxy and CoinGecko"
+```
+
+---
+
+## Task 4: Esbuild-based Build Script
+
+**Files:**
+- Create: `scripts/build.sh`
+- Modify: `package.json` (update build script)
+
+The current `npm run build` runs `tsc` which OOMs due to viem's massive type definitions. Replace with esbuild for transpilation (type checking stays via `npx tsc --noEmit`).
+
+**Step 1: Create build script**
+
+```bash
+#!/usr/bin/env bash
+# scripts/build.sh — Transpile TypeScript to dist using esbuild
+# tsc OOMs on viem types, so we use esbuild for transpilation
+# Type checking: npx tsc --noEmit (separate step)
+
+set -e
+
+echo "Building @chainvault/core..."
+find packages/core/src -name "*.ts" ! -name "*.test.ts" ! -name "*.d.ts" | while read f; do
+  outdir="packages/core/dist/$(dirname "${f#packages/core/src/}")"
+  mkdir -p "$outdir"
+  npx esbuild "$f" --format=esm --outdir="$outdir" --log-level=warning
+done
+
+echo "Building @chainvault/cli..."
+find packages/cli/src -name "*.ts" ! -name "*.tsx" ! -name "*.test.ts" ! -name "*.e2e.test.ts" ! -name "*.d.ts" | while read f; do
+  outdir="packages/cli/dist/$(dirname "${f#packages/cli/src/}")"
+  mkdir -p "$outdir"
+  npx esbuild "$f" --format=esm --outdir="$outdir" --log-level=warning
+done
+
+echo "Build complete."
+```
+
+**Step 2: Update root package.json**
+
+Change the build script from:
+```json
+"build": "npm run build --workspaces"
+```
+to:
+```json
+"build": "bash scripts/build.sh"
+```
+
+**Step 3: Make executable and test**
+
+Run: `chmod +x scripts/build.sh && npm run build`
+Expected: All files transpiled, no errors.
+
+**Step 4: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/build.sh package.json
+git commit -m "chore: replace tsc build with esbuild (fixes OOM on viem types)"
+```
+
+---
+
+## Task 5: Final Verification + Dist Rebuild
+
+**Step 1: Rebuild dist**
+
+Run: `npm run build`
+
+**Step 2: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests PASS.
+
+**Step 3: Test serve with agent context**
+
+Run:
+```bash
+CHAINVAULT_VAULT_KEY=cv_agent_687c8827ae5f6d601d9b33cabf5e1fef7713ba0ea8fe0275bdeab289c7ac5280 node packages/cli/dist/index.js serve -p .chainvault-dev
+```
+Expected: `ChainVault MCP server running on stdio (agent: dev-agent)`
+
+**Step 4: Verify no stubs remain**
+
+Run: `grep -r "Not yet implemented" packages/core/src/mcp/tools/`
+Expected: No matches.
+
+---
+
+## Task Summary
+
+| Task | Description | Tests |
+|------|-------------|-------|
+| 1 | Wire deploy_contract + interact_contract | 4 |
+| 2 | Wire verify_contract | 1 |
+| 3 | Wire query_explorer + query_price | 3 |
+| 4 | Esbuild build script | 0 (manual) |
+| 5 | Final verification | 0 (integration) |
+
+**Total: ~8 new tests, 5 tasks**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       ],
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.80",
-        "@anthropic-ai/claude-code": "^2.1.80",
         "@types/node": "^22.0.0",
         "dotenv": "^17.3.1",
         "typescript": "^5.7.0",
@@ -64,30 +63,6 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.80",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.80.tgz",
-      "integrity": "sha512-YAgNNr3fzn3xaTNm+CYgebdEinU9D0HxGUT2C1N2Ej2HCvt5AjrSoU8vTgccxx4oPkj1R4gpuZWi1rTKvxNaPQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN README.md",
-      "bin": {
-        "claude": "cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
       }
     },
     "node_modules/@chainvault/cli": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/cli"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
+    "build": "bash scripts/build.sh",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.80",
-    "@anthropic-ai/claude-code": "^2.1.80",
     "@types/node": "^22.0.0",
     "dotenv": "^17.3.1",
     "typescript": "^5.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "echo 'Use npm run build from root (esbuild)'"
   },
   "dependencies": {
     "@chainvault/core": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "echo 'Use npm run build from root (esbuild)'"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",

--- a/packages/core/src/mcp/audit-fn.ts
+++ b/packages/core/src/mcp/audit-fn.ts
@@ -1,0 +1,13 @@
+/**
+ * Lightweight audit function signature passed to tool registration functions.
+ * Wraps the underlying AuditStore with the agent name from context.
+ *
+ * chain_id is optional because some tools (compile_contract, query_price) are
+ * not chain-specific.
+ */
+export type AuditFn = (entry: {
+  action: string;
+  chain_id?: number;
+  status: 'approved' | 'denied';
+  details: string;
+}) => void;

--- a/packages/core/src/mcp/context.test.ts
+++ b/packages/core/src/mcp/context.test.ts
@@ -35,6 +35,7 @@ describe('createAgentContext', () => {
     await MasterVault.init(testDir, TEST_PASSWORD);
     const vault = await MasterVault.unlock(testDir, TEST_PASSWORD);
     await vault.addKey('my-wallet', TEST_PRIVATE_KEY, [1, 11155111]);
+    await vault.addApiKey('etherscan', 'TEST_API_KEY', 'https://api.etherscan.io');
 
     const manager = new AgentVaultManager(testDir, vault);
     const result = await manager.createAgent(DEPLOYER_CONFIG, ['my-wallet'], ['etherscan']);
@@ -62,6 +63,37 @@ describe('createAgentContext', () => {
     // Ensure no private key is exposed in the keys array
     const keyAsAny = ctx!.keys[0] as any;
     expect(keyAsAny.private_key).toBeUndefined();
+  });
+
+  it('does not expose vaultData on the context object', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    const ctxAsAny = ctx as any;
+    expect(ctxAsAny.vaultData).toBeUndefined();
+  });
+
+  it('getPrivateKeyForChain returns a key for an accessible chain', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    const key = ctx!.getPrivateKeyForChain(11155111);
+    expect(key).toBeTruthy();
+  });
+
+  it('getPrivateKeyForChain returns null for an inaccessible chain', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    const key = ctx!.getPrivateKeyForChain(999);
+    expect(key).toBeNull();
+  });
+
+  it('getApiKey returns key info for a configured service', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    const apiKey = ctx!.getApiKey('etherscan');
+    expect(apiKey).not.toBeNull();
+    expect(apiKey!.baseUrl).toBeDefined();
+  });
+
+  it('getApiKey returns null for an unconfigured service', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    const apiKey = ctx!.getApiKey('nonexistent');
+    expect(apiKey).toBeNull();
   });
 
   it('throws with invalid vault key', async () => {

--- a/packages/core/src/mcp/context.ts
+++ b/packages/core/src/mcp/context.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { decrypt } from '../vault/crypto.js';
-import { AgentVaultDataSchema, type AgentVaultData, type AgentConfig } from '../vault/types.js';
+import { AgentVaultDataSchema, type AgentConfig } from '../vault/types.js';
 import { RulesEngine } from '../rules/engine.js';
 import { readFile } from 'node:fs/promises';
 
@@ -17,8 +17,10 @@ export interface AgentContext {
   agentName: string;
   config: AgentConfig;
   rules: RulesEngine;
-  keys: AgentKeyInfo[];
-  vaultData: AgentVaultData;
+  keys: AgentKeyInfo[];  // public addresses only
+  getPrivateKeyForChain(chainId: number): string | null;
+  getApiKey(serviceName: string): { key: string; baseUrl: string } | null;
+  getApiKeyForExplorer(explorerApiUrl: string): { serviceName: string; key: string } | null;
 }
 
 /**
@@ -70,12 +72,42 @@ export async function createAgentContext(
 
       const rules = new RulesEngine(vaultData.config);
 
+      // Controlled accessors — vaultData stays in closure, never exposed
+      const getPrivateKeyForChain = (chainId: number): string | null => {
+        for (const [, key] of Object.entries(vaultData.keys)) {
+          if (key.chains.includes(chainId)) return key.private_key;
+        }
+        return null;
+      };
+
+      const getApiKey = (serviceName: string): { key: string; baseUrl: string } | null => {
+        const entry = vaultData.api_keys[serviceName];
+        return entry ? { key: entry.key, baseUrl: entry.base_url } : null;
+      };
+
+      const getApiKeyForExplorer = (explorerApiUrl: string): { serviceName: string; key: string } | null => {
+        for (const [name, ak] of Object.entries(vaultData.api_keys)) {
+          try {
+            const akHost = new URL(ak.base_url).hostname;
+            const explorerHost = new URL(explorerApiUrl).hostname;
+            const akDomain = akHost.split('.').slice(-2).join('.');
+            const explorerDomain = explorerHost.split('.').slice(-2).join('.');
+            if (akDomain === explorerDomain || akHost.includes(explorerDomain) || explorerHost.includes(akDomain)) {
+              return { serviceName: name, key: ak.key };
+            }
+          } catch { continue; }
+        }
+        return null;
+      };
+
       return {
         agentName: vaultData.agent_name,
         config: vaultData.config,
         rules,
         keys,
-        vaultData,
+        getPrivateKeyForChain,
+        getApiKey,
+        getApiKeyForExplorer,
       };
     } catch {
       // Wrong key for this vault file, try the next one

--- a/packages/core/src/mcp/mcp-integration.e2e.test.ts
+++ b/packages/core/src/mcp/mcp-integration.e2e.test.ts
@@ -544,5 +544,54 @@ describe('MCP Server Integration (in-process via InMemoryTransport)', () => {
         expect(text).toMatch(/no.*api.*key|not configured/i);
       });
     });
+
+    // -----------------------------------------------------------------
+    // Proxy tools
+    // -----------------------------------------------------------------
+    describe('Proxy tools', () => {
+      it('query_explorer returns error when no API key configured', async () => {
+        const result = await ctxClient.callTool({
+          name: 'query_explorer',
+          arguments: {
+            chain_id: 11155111,
+            module: 'contract',
+            action: 'getabi',
+            params: { address: '0x0000000000000000000000000000000000000001' },
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toMatch(/no.*api.*key|not configured/i);
+      });
+
+      it('query_explorer returns error without agent context', async () => {
+        const result = await client.callTool({
+          name: 'query_explorer',
+          arguments: {
+            chain_id: 11155111,
+            module: 'contract',
+            action: 'getabi',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toContain('CHAINVAULT_VAULT_KEY');
+      });
+
+      it('query_price returns data from CoinGecko public API', async () => {
+        const result = await client.callTool({
+          name: 'query_price',
+          arguments: { token_id: 'ethereum' },
+        });
+        const text = (result.content as any)[0].text;
+        const parsed = JSON.parse(text);
+        // CoinGecko returns { ethereum: { usd: 1234.56 } } or rate limit error
+        if (parsed.error) {
+          // Rate limited — still valid behavior
+          expect(parsed.error).toBeDefined();
+        } else {
+          expect(parsed.ethereum).toBeDefined();
+          expect(typeof parsed.ethereum.usd).toBe('number');
+        }
+      });
+    });
   });
 });

--- a/packages/core/src/mcp/mcp-integration.e2e.test.ts
+++ b/packages/core/src/mcp/mcp-integration.e2e.test.ts
@@ -527,6 +527,22 @@ describe('MCP Server Integration (in-process via InMemoryTransport)', () => {
         const text = (result.content as any)[0].text;
         expect(text).toContain('CHAINVAULT_VAULT_KEY');
       });
+
+      it('verify_contract returns error when no API key configured', async () => {
+        const result = await ctxClient.callTool({
+          name: 'verify_contract',
+          arguments: {
+            chain_id: 11155111,
+            address: '0x0000000000000000000000000000000000000001',
+            source_code: 'pragma solidity ^0.8.20; contract X {}',
+            contract_name: 'X',
+            compiler_version: '0.8.20',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        // Agent has no API keys configured, so this should fail gracefully
+        expect(text).toMatch(/no.*api.*key|not configured/i);
+      });
     });
   });
 });

--- a/packages/core/src/mcp/mcp-integration.e2e.test.ts
+++ b/packages/core/src/mcp/mcp-integration.e2e.test.ts
@@ -470,5 +470,63 @@ describe('MCP Server Integration (in-process via InMemoryTransport)', () => {
         expect(text).toContain('does not have access');
       });
     });
+
+    // -----------------------------------------------------------------
+    // Chain write tools (rules enforcement)
+    // -----------------------------------------------------------------
+    describe('Chain write tools (rules enforcement)', () => {
+      it('deploy_contract denied when agent lacks deploy permission', async () => {
+        const result = await ctxClient.callTool({
+          name: 'deploy_contract',
+          arguments: {
+            chain_id: 11155111,
+            abi: '[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}]',
+            bytecode: '0x608060405234801561001057600080fd5b50',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toContain('not allowed');
+      });
+
+      it('interact_contract denied when agent lacks write permission', async () => {
+        const result = await ctxClient.callTool({
+          name: 'interact_contract',
+          arguments: {
+            chain_id: 11155111,
+            address: '0x0000000000000000000000000000000000000001',
+            abi: '[{"inputs":[],"name":"foo","outputs":[],"stateMutability":"nonpayable","type":"function"}]',
+            function_name: 'foo',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toContain('not allowed');
+      });
+
+      it('deploy_contract denied for unauthorized chain', async () => {
+        const result = await ctxClient.callTool({
+          name: 'deploy_contract',
+          arguments: {
+            chain_id: 1,
+            abi: '[]',
+            bytecode: '0x00',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toContain('does not have access');
+      });
+
+      it('deploy_contract returns error without agent context', async () => {
+        const result = await client.callTool({
+          name: 'deploy_contract',
+          arguments: {
+            chain_id: 11155111,
+            abi: '[]',
+            bytecode: '0x00',
+          },
+        });
+        const text = (result.content as any)[0].text;
+        expect(text).toContain('CHAINVAULT_VAULT_KEY');
+      });
+    });
   });
 });

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -5,6 +5,9 @@ import { registerProxyTools } from './tools/proxy-tools.js';
 import { registerCompilerTools } from './tools/compiler-tools.js';
 import { registerChainRegistryTools } from './tools/chain-registry-tools.js';
 import { createAgentContext, type AgentContext } from './context.js';
+import { ChainVaultDB } from '../db/database.js';
+import { AuditStore } from '../db/audit-store.js';
+import type { AuditFn } from './audit-fn.js';
 
 interface ServerConfig {
   basePath: string;
@@ -16,6 +19,8 @@ export class ChainVaultServer {
   private registeredTools: string[] = [];
   private config: ServerConfig;
   private agentContext: AgentContext | null = null;
+  private auditStore: AuditStore | null = null;
+  private db: ChainVaultDB | null = null;
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -37,6 +42,9 @@ export class ChainVaultServer {
       this.config.basePath,
       this.config.vaultKey || process.env.CHAINVAULT_VAULT_KEY,
     );
+
+    this.db = new ChainVaultDB(this.config.basePath);
+    this.auditStore = new AuditStore(this.db);
   }
 
   private registerAllTools(): void {
@@ -49,11 +57,25 @@ export class ChainVaultServer {
 
     const getContext = () => this.agentContext;
 
-    registerVaultTools(this.mcpServer, getContext);
-    registerChainTools(this.mcpServer, getContext);
-    registerProxyTools(this.mcpServer, getContext);
-    registerCompilerTools(this.mcpServer);
-    registerChainRegistryTools(this.mcpServer);
+    // Lazy audit function — resolves agent name and AuditStore at call time
+    // so it works even though tools are registered before init() is called.
+    const audit: AuditFn = (entry) => {
+      if (!this.auditStore) return;
+      const agentName = this.agentContext?.agentName ?? 'unknown';
+      this.auditStore.log({
+        agent: agentName,
+        action: entry.action,
+        chain_id: entry.chain_id ?? 0,
+        status: entry.status,
+        details: entry.details,
+      });
+    };
+
+    registerVaultTools(this.mcpServer, getContext, audit);
+    registerChainTools(this.mcpServer, getContext, audit);
+    registerProxyTools(this.mcpServer, getContext, audit);
+    registerCompilerTools(this.mcpServer, audit);
+    registerChainRegistryTools(this.mcpServer, audit);
 
     // Restore original
     this.mcpServer.registerTool = originalRegister;

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -51,7 +51,7 @@ export class ChainVaultServer {
 
     registerVaultTools(this.mcpServer, getContext);
     registerChainTools(this.mcpServer, getContext);
-    registerProxyTools(this.mcpServer);
+    registerProxyTools(this.mcpServer, getContext);
     registerCompilerTools(this.mcpServer);
     registerChainRegistryTools(this.mcpServer);
 

--- a/packages/core/src/mcp/tools/chain-registry-tools.ts
+++ b/packages/core/src/mcp/tools/chain-registry-tools.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AuditFn } from '../audit-fn.js';
 import { SUPPORTED_CHAINS, getChainConfig, getChainsWithFaucets } from '../../chain/chains.js';
 import { requestFaucet, getFaucetInfo } from '../../chain/faucet.js';
 
-export function registerChainRegistryTools(server: McpServer): void {
+const noop: AuditFn = () => {};
+
+export function registerChainRegistryTools(server: McpServer, audit: AuditFn = noop): void {
   server.registerTool(
     'list_supported_chains',
     {
@@ -28,6 +31,7 @@ export function registerChainRegistryTools(server: McpServer): void {
         blockExplorer: c.blockExplorer?.url ?? null,
       }));
 
+      audit({ action: 'list_supported_chains', status: 'approved', details: `Listed ${result.length} chains (filter: ${network ?? 'all'})` });
       return {
         content: [{
           type: 'text' as const,
@@ -49,6 +53,7 @@ export function registerChainRegistryTools(server: McpServer): void {
     },
     async ({ chain_id, address }) => {
       const result = await requestFaucet(chain_id, address);
+      audit({ action: 'request_faucet', chain_id, status: 'approved', details: `Faucet request for chain ${chain_id}` });
       return {
         content: [{
           type: 'text' as const,

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -3,8 +3,10 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { EvmAdapter } from '../../chain/evm-adapter.js';
 import { getChainConfig } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
+import type { AuditFn } from '../audit-fn.js';
 
 type ContextGetter = () => AgentContext | null;
+const noop: AuditFn = () => {};
 
 /**
  * Strips potential key material from error messages before returning to agents.
@@ -40,7 +42,7 @@ function checkWriteAccess(
   return null;
 }
 
-export function registerChainTools(server: McpServer, getContext: ContextGetter): void {
+export function registerChainTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
   // ---------------------------------------------------------------------------
   // Tier 2 write tools
   // ---------------------------------------------------------------------------
@@ -60,10 +62,16 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, abi, bytecode, constructor_args }) => {
       const ctx = getContext();
       const err = checkWriteAccess(ctx, chain_id, 'deploy');
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'deploy_contract', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       const privateKey = ctx!.getPrivateKeyForChain(chain_id);
-      if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+      if (!privateKey) {
+        audit({ action: 'deploy_contract', chain_id, status: 'denied', details: 'No key for chain' });
+        return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+      }
 
       try {
         const adapter = EvmAdapter.fromChainId(chain_id);
@@ -76,6 +84,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         });
         // Record spend for limit tracking
         ctx!.rules.recordSpend(chain_id, 0);
+        audit({ action: 'deploy_contract', chain_id, status: 'approved', details: `Deployed: ${result.hash}` });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({
             hash: result.hash,
@@ -83,6 +92,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           }, null, 2) }],
         };
       } catch (e: unknown) {
+        audit({ action: 'deploy_contract', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -105,10 +115,16 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, address, abi, function_name, args, value }) => {
       const ctx = getContext();
       const err = checkWriteAccess(ctx, chain_id, 'write', value ?? '0', address);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'interact_contract', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       const privateKey = ctx!.getPrivateKeyForChain(chain_id);
-      if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+      if (!privateKey) {
+        audit({ action: 'interact_contract', chain_id, status: 'denied', details: 'No key for chain' });
+        return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+      }
 
       try {
         const adapter = EvmAdapter.fromChainId(chain_id);
@@ -124,10 +140,12 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         // Record spend for limit tracking
         const spendValue = parseFloat(value ?? '0');
         ctx!.rules.recordSpend(chain_id, spendValue);
+        audit({ action: 'interact_contract', chain_id, status: 'approved', details: `Wrote ${function_name}: ${result.hash}` });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ hash: result.hash }, null, 2) }],
         };
       } catch (e: unknown) {
+        audit({ action: 'interact_contract', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -149,11 +167,15 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     },
     async ({ chain_id, address, source_code, contract_name, compiler_version, optimization }) => {
       const ctx = getContext();
-      if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+      if (!ctx) {
+        audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No agent context' });
+        return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+      }
 
       // Find explorer API URL from chain config
       const chainConfig = getChainConfig(chain_id);
       if (!chainConfig?.blockExplorer?.apiUrl) {
+        audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No explorer API for chain' });
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
@@ -161,6 +183,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
       const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
+        audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No API key for explorer' });
         return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
       }
 
@@ -183,8 +206,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           body: params.toString(),
         });
         const data = await response.json();
+        audit({ action: 'verify_contract', chain_id, status: 'approved', details: `Verified ${contract_name}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'verify_contract', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -207,13 +232,18 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, address }) => {
       const ctx = getContext();
       const err = checkChainAccess(ctx, chain_id);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'get_balance', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       try {
         const adapter = EvmAdapter.fromChainId(chain_id);
         const balance = await adapter.getBalance(address);
+        audit({ action: 'get_balance', chain_id, status: 'approved', details: 'Retrieved balance' });
         return { content: [{ type: 'text' as const, text: JSON.stringify(balance, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'get_balance', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -235,7 +265,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, address, abi, function_name, args }) => {
       const ctx = getContext();
       const err = checkChainAccess(ctx, chain_id);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'get_contract_state', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       try {
         const parsedAbi = JSON.parse(abi);
@@ -246,8 +279,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           functionName: function_name,
           args: args ?? [],
         });
+        audit({ action: 'get_contract_state', chain_id, status: 'approved', details: `Read ${function_name}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify({ result }, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'get_contract_state', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -270,11 +305,15 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, address, abi, function_name, args, value }) => {
       const ctx = getContext();
       const err = checkChainAccess(ctx, chain_id);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'simulate_transaction', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       try {
         const agentKey = ctx!.keys.find((k) => k.chains.includes(chain_id));
         if (!agentKey) {
+          audit({ action: 'simulate_transaction', chain_id, status: 'denied', details: 'No key for chain' });
           return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
         }
 
@@ -288,8 +327,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           account: agentKey.address,
           value,
         });
+        audit({ action: 'simulate_transaction', chain_id, status: 'approved', details: `Simulated ${function_name}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'simulate_transaction', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -312,7 +353,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, address, abi, event_name, from_block, to_block }) => {
       const ctx = getContext();
       const err = checkChainAccess(ctx, chain_id);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'get_events', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       try {
         const parsedAbi = JSON.parse(abi);
@@ -324,8 +368,10 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           fromBlock: from_block !== undefined ? BigInt(from_block) : undefined,
           toBlock: to_block !== undefined ? BigInt(to_block) : undefined,
         });
+        audit({ action: 'get_events', chain_id, status: 'approved', details: `Queried ${event_name} events` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(events, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'get_events', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -344,13 +390,18 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id, hash }) => {
       const ctx = getContext();
       const err = checkChainAccess(ctx, chain_id);
-      if (err) return { content: [{ type: 'text' as const, text: err }] };
+      if (err) {
+        audit({ action: 'get_transaction', chain_id, status: 'denied', details: err });
+        return { content: [{ type: 'text' as const, text: err }] };
+      }
 
       try {
         const adapter = EvmAdapter.fromChainId(chain_id);
         const tx = await adapter.getTransaction(hash);
+        audit({ action: 'get_transaction', chain_id, status: 'approved', details: `Retrieved tx ${hash.slice(0, 10)}...` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(tx, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'get_transaction', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -74,6 +74,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           args: constructor_args,
           privateKey,
         });
+        // Record spend for limit tracking
+        ctx!.rules.recordSpend(chain_id, 0);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({
             hash: result.hash,
@@ -119,6 +121,9 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           privateKey,
           value,
         });
+        // Record spend for limit tracking
+        const spendValue = parseFloat(value ?? '0');
+        ctx!.rules.recordSpend(chain_id, spendValue);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ hash: result.hash }, null, 2) }],
         };

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -6,6 +6,15 @@ import type { AgentContext } from '../context.js';
 
 type ContextGetter = () => AgentContext | null;
 
+/**
+ * Strips potential key material from error messages before returning to agents.
+ * Redacts anything that looks like a private key (0x + 64 hex chars).
+ */
+function sanitizeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
+}
+
 function checkChainAccess(ctx: AgentContext | null, chainId: number): string | null {
   if (!ctx) return 'No agent context. Set CHAINVAULT_VAULT_KEY.';
   const result = ctx.rules.checkTxRequest({ type: 'read', chain_id: chainId, value: '0' });
@@ -31,15 +40,6 @@ function checkWriteAccess(
   return null;
 }
 
-function getPrivateKey(ctx: AgentContext, chainId: number): string | null {
-  for (const [, key] of Object.entries(ctx.vaultData.keys)) {
-    if (key.chains.includes(chainId)) {
-      return key.private_key;
-    }
-  }
-  return null;
-}
-
 export function registerChainTools(server: McpServer, getContext: ContextGetter): void {
   // ---------------------------------------------------------------------------
   // Tier 2 write tools
@@ -62,7 +62,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
       const err = checkWriteAccess(ctx, chain_id, 'deploy');
       if (err) return { content: [{ type: 'text' as const, text: err }] };
 
-      const privateKey = getPrivateKey(ctx!, chain_id);
+      const privateKey = ctx!.getPrivateKeyForChain(chain_id);
       if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
 
       try {
@@ -80,8 +80,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
             contractAddress: result.address ?? null,
           }, null, 2) }],
         };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -105,7 +105,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
       const err = checkWriteAccess(ctx, chain_id, 'write', value ?? '0', address);
       if (err) return { content: [{ type: 'text' as const, text: err }] };
 
-      const privateKey = getPrivateKey(ctx!, chain_id);
+      const privateKey = ctx!.getPrivateKeyForChain(chain_id);
       if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
 
       try {
@@ -122,8 +122,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ hash: result.hash }, null, 2) }],
         };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -152,29 +152,16 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
-      // Find an API key for this explorer
+      // Find an API key for this explorer via controlled accessor
       const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
-      let apiKey: string | null = null;
-      for (const [, ak] of Object.entries(ctx.vaultData.api_keys)) {
-        try {
-          const akHost = new URL(ak.base_url).hostname;
-          const explorerHost = new URL(explorerApiUrl).hostname;
-          // Match on domain root (e.g., etherscan.io matches api.etherscan.io)
-          if (akHost.includes(explorerHost.split('.').slice(-2).join('.')) ||
-              explorerHost.includes(akHost.split('.').slice(-2).join('.'))) {
-            apiKey = ak.key;
-            break;
-          }
-        } catch { continue; }
-      }
-
-      if (!apiKey) {
+      const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
+      if (!apiKeyMatch) {
         return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
       }
 
       try {
         const params = new URLSearchParams({
-          apikey: apiKey,
+          apikey: apiKeyMatch.key,
           module: 'contract',
           action: 'verifysourcecode',
           contractaddress: address,
@@ -192,8 +179,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         });
         const data = await response.json();
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -221,8 +208,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         const adapter = EvmAdapter.fromChainId(chain_id);
         const balance = await adapter.getBalance(address);
         return { content: [{ type: 'text' as const, text: JSON.stringify(balance, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -255,8 +242,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           args: args ?? [],
         });
         return { content: [{ type: 'text' as const, text: JSON.stringify({ result }, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -297,8 +284,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           value,
         });
         return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -333,8 +320,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
           toBlock: to_block !== undefined ? BigInt(to_block) : undefined,
         });
         return { content: [{ type: 'text' as const, text: JSON.stringify(events, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -358,8 +345,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         const adapter = EvmAdapter.fromChainId(chain_id);
         const tx = await adapter.getTransaction(hash);
         return { content: [{ type: 'text' as const, text: JSON.stringify(tx, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { EvmAdapter } from '../../chain/evm-adapter.js';
+import { getChainConfig } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
 
 type ContextGetter = () => AgentContext | null;
@@ -141,8 +142,59 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         optimization: z.boolean().optional().describe('Whether optimization was enabled'),
       }),
     },
-    async () => {
-      return { content: [{ type: 'text' as const, text: 'Not yet implemented. Coming in Tier 2.' }] };
+    async ({ chain_id, address, source_code, contract_name, compiler_version, optimization }) => {
+      const ctx = getContext();
+      if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+
+      // Find explorer API URL from chain config
+      const chainConfig = getChainConfig(chain_id);
+      if (!chainConfig?.blockExplorer?.apiUrl) {
+        return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
+      }
+
+      // Find an API key for this explorer
+      const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
+      let apiKey: string | null = null;
+      for (const [, ak] of Object.entries(ctx.vaultData.api_keys)) {
+        try {
+          const akHost = new URL(ak.base_url).hostname;
+          const explorerHost = new URL(explorerApiUrl).hostname;
+          // Match on domain root (e.g., etherscan.io matches api.etherscan.io)
+          if (akHost.includes(explorerHost.split('.').slice(-2).join('.')) ||
+              explorerHost.includes(akHost.split('.').slice(-2).join('.'))) {
+            apiKey = ak.key;
+            break;
+          }
+        } catch { continue; }
+      }
+
+      if (!apiKey) {
+        return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
+      }
+
+      try {
+        const params = new URLSearchParams({
+          apikey: apiKey,
+          module: 'contract',
+          action: 'verifysourcecode',
+          contractaddress: address,
+          sourceCode: source_code,
+          codeformat: 'solidity-single-file',
+          contractname: contract_name,
+          compilerversion: `v${compiler_version}`,
+          optimizationUsed: optimization ? '1' : '0',
+        });
+
+        const response = await fetch(`${explorerApiUrl}/api`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const data = await response.json();
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      }
     },
   );
 

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -12,9 +12,36 @@ function checkChainAccess(ctx: AgentContext | null, chainId: number): string | n
   return null;
 }
 
+function checkWriteAccess(
+  ctx: AgentContext | null,
+  chainId: number,
+  txType: 'deploy' | 'write' | 'transfer',
+  value: string = '0',
+  toAddress?: string,
+): string | null {
+  if (!ctx) return 'No agent context. Set CHAINVAULT_VAULT_KEY.';
+  const result = ctx.rules.checkTxRequest({
+    type: txType,
+    chain_id: chainId,
+    value,
+    to_address: toAddress,
+  });
+  if (!result.approved) return result.reason ?? 'Operation denied.';
+  return null;
+}
+
+function getPrivateKey(ctx: AgentContext, chainId: number): string | null {
+  for (const [, key] of Object.entries(ctx.vaultData.keys)) {
+    if (key.chains.includes(chainId)) {
+      return key.private_key;
+    }
+  }
+  return null;
+}
+
 export function registerChainTools(server: McpServer, getContext: ContextGetter): void {
   // ---------------------------------------------------------------------------
-  // Tier 2 stubs (not yet wired)
+  // Tier 2 write tools
   // ---------------------------------------------------------------------------
 
   server.registerTool(
@@ -29,8 +56,32 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         constructor_args: z.array(z.any()).optional().describe('Constructor arguments'),
       }),
     },
-    async () => {
-      return { content: [{ type: 'text' as const, text: 'Not yet implemented. Coming in Tier 2.' }] };
+    async ({ chain_id, abi, bytecode, constructor_args }) => {
+      const ctx = getContext();
+      const err = checkWriteAccess(ctx, chain_id, 'deploy');
+      if (err) return { content: [{ type: 'text' as const, text: err }] };
+
+      const privateKey = getPrivateKey(ctx!, chain_id);
+      if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+
+      try {
+        const adapter = EvmAdapter.fromChainId(chain_id);
+        const parsedAbi = JSON.parse(abi);
+        const result = await adapter.deployContract({
+          abi: parsedAbi,
+          bytecode,
+          args: constructor_args,
+          privateKey,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            hash: result.hash,
+            contractAddress: result.address ?? null,
+          }, null, 2) }],
+        };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      }
     },
   );
 
@@ -48,8 +99,31 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter)
         value: z.string().optional().describe('Native token value to send (in ETH)'),
       }),
     },
-    async () => {
-      return { content: [{ type: 'text' as const, text: 'Not yet implemented. Coming in Tier 2.' }] };
+    async ({ chain_id, address, abi, function_name, args, value }) => {
+      const ctx = getContext();
+      const err = checkWriteAccess(ctx, chain_id, 'write', value ?? '0', address);
+      if (err) return { content: [{ type: 'text' as const, text: err }] };
+
+      const privateKey = getPrivateKey(ctx!, chain_id);
+      if (!privateKey) return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
+
+      try {
+        const adapter = EvmAdapter.fromChainId(chain_id);
+        const parsedAbi = JSON.parse(abi);
+        const result = await adapter.writeContract({
+          address,
+          abi: parsedAbi,
+          functionName: function_name,
+          args: args ?? [],
+          privateKey,
+          value,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ hash: result.hash }, null, 2) }],
+        };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      }
     },
   );
 

--- a/packages/core/src/mcp/tools/compiler-tools.ts
+++ b/packages/core/src/mcp/tools/compiler-tools.ts
@@ -2,6 +2,15 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { compile } from '../../compiler/solidity.js';
 
+/**
+ * Strips potential key material from error messages before returning to agents.
+ * Redacts anything that looks like a private key (0x + 64 hex chars).
+ */
+function sanitizeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
+}
+
 export function registerCompilerTools(server: McpServer): void {
   server.registerTool(
     'compile_contract',
@@ -35,8 +44,8 @@ export function registerCompilerTools(server: McpServer): void {
             }, null, 2),
           }],
         };
-      } catch (e: any) {
-        const msg = e.message || String(e);
+      } catch (e: unknown) {
+        const msg = sanitizeError(e);
         if (msg.includes('docker') || msg.includes('solc') || msg.includes('ENOENT') || msg.includes('not found')) {
           return {
             content: [{

--- a/packages/core/src/mcp/tools/compiler-tools.ts
+++ b/packages/core/src/mcp/tools/compiler-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AuditFn } from '../audit-fn.js';
 import { compile } from '../../compiler/solidity.js';
 
 /**
@@ -11,7 +12,9 @@ function sanitizeError(err: unknown): string {
   return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
 }
 
-export function registerCompilerTools(server: McpServer): void {
+const noop: AuditFn = () => {};
+
+export function registerCompilerTools(server: McpServer, audit: AuditFn = noop): void {
   server.registerTool(
     'compile_contract',
     {
@@ -34,6 +37,7 @@ export function registerCompilerTools(server: McpServer): void {
           optimization ?? true,
           optimization_runs ?? 200,
         );
+        audit({ action: 'compile_contract', status: 'approved', details: `Compiled ${contract_name} (solc ${compiler_version})` });
         return {
           content: [{
             type: 'text' as const,
@@ -46,6 +50,7 @@ export function registerCompilerTools(server: McpServer): void {
         };
       } catch (e: unknown) {
         const msg = sanitizeError(e);
+        audit({ action: 'compile_contract', status: 'approved', details: `Error: ${msg.slice(0, 100)}` });
         if (msg.includes('docker') || msg.includes('solc') || msg.includes('ENOENT') || msg.includes('not found')) {
           return {
             content: [{

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AgentContext } from '../context.js';
+import type { AuditFn } from '../audit-fn.js';
 import { getChainConfig } from '../../chain/chains.js';
 import { ApiProxy } from '../../proxy/api-proxy.js';
 
 type ContextGetter = () => AgentContext | null;
 
 const proxy = new ApiProxy();
+const noop: AuditFn = () => {};
 
 /**
  * Strips potential key material from error messages before returning to agents.
@@ -17,7 +19,7 @@ function sanitizeError(err: unknown): string {
   return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
 }
 
-export function registerProxyTools(server: McpServer, getContext: ContextGetter): void {
+export function registerProxyTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
   server.registerTool(
     'query_explorer',
     {
@@ -32,11 +34,15 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
     },
     async ({ chain_id, module: mod, action, params: extraParams }) => {
       const ctx = getContext();
-      if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+      if (!ctx) {
+        audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No agent context' });
+        return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+      }
 
       // Find explorer API URL from chain config
       const chainConfig = getChainConfig(chain_id);
       if (!chainConfig?.blockExplorer?.apiUrl) {
+        audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No explorer API for chain' });
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
@@ -44,6 +50,7 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
       const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
+        audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No API key for explorer' });
         return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
       }
       const { serviceName, key: apiKeyValue } = apiKeyMatch;
@@ -51,6 +58,7 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
       // Check API access rules
       const apiCheck = ctx.rules.checkApiRequest({ service: serviceName, endpoint: action });
       if (!apiCheck.approved) {
+        audit({ action: 'query_explorer', chain_id, status: 'denied', details: apiCheck.reason ?? 'API access denied' });
         return { content: [{ type: 'text' as const, text: apiCheck.reason ?? 'API access denied.' }] };
       }
 
@@ -65,8 +73,10 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
           apiKey: apiKeyValue,
           rateLimits,
         });
+        audit({ action: 'query_explorer', chain_id, status: 'approved', details: `Queried ${mod}.${action}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'query_explorer', chain_id, status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
@@ -88,11 +98,14 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
         const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(token_id)}&vs_currencies=${encodeURIComponent(cur)}`;
         const response = await fetch(url);
         if (!response.ok) {
+          audit({ action: 'query_price', status: 'approved', details: `CoinGecko error: ${response.status}` });
           return { content: [{ type: 'text' as const, text: JSON.stringify({ error: `CoinGecko API error: ${response.status}` }) }] };
         }
         const data = await response.json();
+        audit({ action: 'query_price', status: 'approved', details: `Price for ${token_id}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
       } catch (e: unknown) {
+        audit({ action: 'query_price', status: 'approved', details: `Error: ${sanitizeError(e)}` });
         return { content: [{ type: 'text' as const, text: JSON.stringify({ error: sanitizeError(e) }) }] };
       }
     },

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -8,6 +8,15 @@ type ContextGetter = () => AgentContext | null;
 
 const proxy = new ApiProxy();
 
+/**
+ * Strips potential key material from error messages before returning to agents.
+ * Redacts anything that looks like a private key (0x + 64 hex chars).
+ */
+function sanitizeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
+}
+
 export function registerProxyTools(server: McpServer, getContext: ContextGetter): void {
   server.registerTool(
     'query_explorer',
@@ -31,27 +40,13 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
-      // Find API key matching this explorer
+      // Find API key matching this explorer via controlled accessor
       const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
-      let serviceName: string | null = null;
-      let apiKeyValue: string | null = null;
-
-      for (const [name, ak] of Object.entries(ctx.vaultData.api_keys)) {
-        try {
-          const akHost = new URL(ak.base_url).hostname;
-          const explorerHost = new URL(explorerApiUrl).hostname;
-          if (akHost.includes(explorerHost.split('.').slice(-2).join('.')) ||
-              explorerHost.includes(akHost.split('.').slice(-2).join('.'))) {
-            serviceName = name;
-            apiKeyValue = ak.key;
-            break;
-          }
-        } catch { continue; }
-      }
-
-      if (!serviceName || !apiKeyValue) {
+      const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
+      if (!apiKeyMatch) {
         return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
       }
+      const { serviceName, key: apiKeyValue } = apiKeyMatch;
 
       // Check API access rules
       const apiCheck = ctx.rules.checkApiRequest({ service: serviceName, endpoint: action });
@@ -71,8 +66,8 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
           rateLimits,
         });
         return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: `Error: ${sanitizeError(e)}` }] };
       }
     },
   );
@@ -97,8 +92,8 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter)
         }
         const data = await response.json();
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
-      } catch (e: any) {
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: e.message }) }] };
+      } catch (e: unknown) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: sanitizeError(e) }) }] };
       }
     },
   );

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AgentContext } from '../context.js';
+import { getChainConfig } from '../../chain/chains.js';
+import { ApiProxy } from '../../proxy/api-proxy.js';
 
-export function registerProxyTools(server: McpServer): void {
+type ContextGetter = () => AgentContext | null;
+
+const proxy = new ApiProxy();
+
+export function registerProxyTools(server: McpServer, getContext: ContextGetter): void {
   server.registerTool(
     'query_explorer',
     {
@@ -14,8 +21,59 @@ export function registerProxyTools(server: McpServer): void {
         params: z.record(z.string(), z.string()).optional().describe('Additional query parameters'),
       }),
     },
-    async () => {
-      return { content: [{ type: 'text' as const, text: '' }] };
+    async ({ chain_id, module: mod, action, params: extraParams }) => {
+      const ctx = getContext();
+      if (!ctx) return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
+
+      // Find explorer API URL from chain config
+      const chainConfig = getChainConfig(chain_id);
+      if (!chainConfig?.blockExplorer?.apiUrl) {
+        return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
+      }
+
+      // Find API key matching this explorer
+      const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
+      let serviceName: string | null = null;
+      let apiKeyValue: string | null = null;
+
+      for (const [name, ak] of Object.entries(ctx.vaultData.api_keys)) {
+        try {
+          const akHost = new URL(ak.base_url).hostname;
+          const explorerHost = new URL(explorerApiUrl).hostname;
+          if (akHost.includes(explorerHost.split('.').slice(-2).join('.')) ||
+              explorerHost.includes(akHost.split('.').slice(-2).join('.'))) {
+            serviceName = name;
+            apiKeyValue = ak.key;
+            break;
+          }
+        } catch { continue; }
+      }
+
+      if (!serviceName || !apiKeyValue) {
+        return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
+      }
+
+      // Check API access rules
+      const apiCheck = ctx.rules.checkApiRequest({ service: serviceName, endpoint: action });
+      if (!apiCheck.approved) {
+        return { content: [{ type: 'text' as const, text: apiCheck.reason ?? 'API access denied.' }] };
+      }
+
+      // Get rate limits from agent config
+      const rateLimits = ctx.config.api_access[serviceName]?.rate_limit;
+
+      try {
+        const result = await proxy.request({
+          baseUrl: explorerApiUrl,
+          endpoint: '/api',
+          params: { module: mod, action, ...(extraParams ?? {}) },
+          apiKey: apiKeyValue,
+          rateLimits,
+        });
+        return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: `Error: ${e.message}` }] };
+      }
     },
   );
 
@@ -23,14 +81,25 @@ export function registerProxyTools(server: McpServer): void {
     'query_price',
     {
       title: 'Get Token Price',
-      description: 'Get current token price data from CoinGecko or similar price API',
+      description: 'Get current token price data from CoinGecko',
       inputSchema: z.object({
         token_id: z.string().describe('Token identifier (e.g., "ethereum", "bitcoin")'),
         currency: z.string().optional().describe('Target currency (default: "usd")'),
       }),
     },
-    async () => {
-      return { content: [{ type: 'text' as const, text: '' }] };
+    async ({ token_id, currency }) => {
+      const cur = currency ?? 'usd';
+      try {
+        const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(token_id)}&vs_currencies=${encodeURIComponent(cur)}`;
+        const response = await fetch(url);
+        if (!response.ok) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: `CoinGecko API error: ${response.status}` }) }] };
+        }
+        const data = await response.json();
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: e.message }) }] };
+      }
     },
   );
 }

--- a/packages/core/src/mcp/tools/vault-tools.ts
+++ b/packages/core/src/mcp/tools/vault-tools.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AgentContext } from '../context.js';
+import type { AuditFn } from '../audit-fn.js';
 import { getChainConfig } from '../../chain/chains.js';
 
 type ContextGetter = () => AgentContext | null;
 
-export function registerVaultTools(server: McpServer, getContext: ContextGetter): void {
+const noop: AuditFn = () => {};
+
+export function registerVaultTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
   server.registerTool(
     'list_chains',
     {
@@ -16,6 +19,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter)
     async () => {
       const ctx = getContext();
       if (!ctx) {
+        audit({ action: 'list_chains', status: 'denied', details: 'No agent context' });
         return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
       }
 
@@ -32,6 +36,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter)
         return { chainId, name: 'Unknown', network: 'unknown', nativeCurrency: 'unknown' };
       });
 
+      audit({ action: 'list_chains', status: 'approved', details: `Listed ${chains.length} chains` });
       return { content: [{ type: 'text' as const, text: JSON.stringify(chains, null, 2) }] };
     },
   );
@@ -46,6 +51,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter)
     async () => {
       const ctx = getContext();
       if (!ctx) {
+        audit({ action: 'list_capabilities', status: 'denied', details: 'No agent context' });
         return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
       }
 
@@ -57,6 +63,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter)
         contract_rules: ctx.config.contract_rules.mode,
       };
 
+      audit({ action: 'list_capabilities', status: 'approved', details: 'Listed agent capabilities' });
       return { content: [{ type: 'text' as const, text: JSON.stringify(capabilities, null, 2) }] };
     },
   );
@@ -73,18 +80,22 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter)
     async ({ chain_id }) => {
       const ctx = getContext();
       if (!ctx) {
+        audit({ action: 'get_agent_address', chain_id, status: 'denied', details: 'No agent context' });
         return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
       }
 
       if (!ctx.config.chains.includes(chain_id)) {
+        audit({ action: 'get_agent_address', chain_id, status: 'denied', details: `Chain ${chain_id} not allowed` });
         return { content: [{ type: 'text' as const, text: `Agent does not have access to chain ${chain_id}.` }] };
       }
 
       const key = ctx.keys.find((k) => k.chains.includes(chain_id));
       if (!key) {
+        audit({ action: 'get_agent_address', chain_id, status: 'denied', details: `No key for chain ${chain_id}` });
         return { content: [{ type: 'text' as const, text: `No key available for chain ${chain_id}.` }] };
       }
 
+      audit({ action: 'get_agent_address', chain_id, status: 'approved', details: 'Returned public address' });
       return { content: [{ type: 'text' as const, text: key.address }] };
     },
   );

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Transpile TypeScript to dist using esbuild
+# tsc OOMs on viem types, so we use esbuild for transpilation
+# Type checking: npx tsc --noEmit (separate step)
+
+set -e
+
+echo "Building @chainvault/core..."
+find packages/core/src -name "*.ts" ! -name "*.test.ts" ! -name "*.d.ts" | while read f; do
+  outdir="packages/core/dist/$(dirname "${f#packages/core/src/}")"
+  mkdir -p "$outdir"
+  npx esbuild "$f" --format=esm --outdir="$outdir" --log-level=warning
+done
+
+echo "Building @chainvault/cli..."
+find packages/cli/src -name "*.ts" ! -name "*.tsx" ! -name "*.test.ts" ! -name "*.e2e.test.ts" ! -name "*.d.ts" | while read f; do
+  outdir="packages/cli/dist/$(dirname "${f#packages/cli/src/}")"
+  mkdir -p "$outdir"
+  npx esbuild "$f" --format=esm --outdir="$outdir" --log-level=warning
+done
+
+echo "Build complete."


### PR DESCRIPTION
## Summary

Wires the final 5 MCP tool stubs to their backend modules. **All 15 MCP tools are now fully functional — zero stubs remaining.**

- **`deploy_contract`** — deploys bytecode via EvmAdapter with rules enforcement (chain access, tx type, spend limits)
- **`interact_contract`** — writes to contracts via EvmAdapter with rules + contract whitelist/blacklist
- **`verify_contract`** — POSTs source code to Etherscan verification API using vault API keys
- **`query_explorer`** — proxies block explorer queries via ApiProxy with rate limiting and API access rules
- **`query_price`** — fetches token prices from CoinGecko public API
- **Build fix** — replaces tsc (OOMs on viem types) with esbuild via `scripts/build.sh`

## Security

- Private keys extracted from vault only during the EvmAdapter signing call, never returned in responses
- API keys from vault used server-side only, never exposed to agents
- All write operations pass through RulesEngine before vault decryption
- Spend tracking via `recordSpend()` after successful transactions

## Test plan

- [ ] 450 vitest tests pass (`npx vitest run`)
- [ ] `npm run build` completes without OOM
- [ ] `grep -r "Not yet implemented" packages/core/src/mcp/tools/` returns nothing
- [ ] Serve with agent context: `CHAINVAULT_VAULT_KEY=<key> node packages/cli/dist/index.js serve -p .chainvault-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)