### PR TITLE
Support decimal ETH strings in estimateGas, writeContract, and simulateTransaction

### DIFF
--- a/packages/core/src/chain/evm-adapter.test.ts
+++ b/packages/core/src/chain/evm-adapter.test.ts
@@ -132,3 +132,45 @@ describe('EvmAdapter.fromChainId', () => {
     expect(fallbackFn).toHaveBeenCalled();
   });
 });
+
+describe('EvmAdapter - Decimal ETH value handling (parseEther)', () => {
+  let adapter: ChainAdapter;
+
+  beforeEach(() => {
+    adapter = new EvmAdapter('https://rpc.example.com', 11155111);
+  });
+
+  it('estimates gas with decimal ETH value', async () => {
+    const estimate = await adapter.estimateGas({
+      to: '0x1234567890abcdef1234567890abcdef12345678',
+      value: '0.5',
+    });
+    expect(estimate.gasLimit).toBeDefined();
+    expect(estimate.gasPriceGwei).toBeDefined();
+    expect(estimate.estimatedCostEth).toBeDefined();
+
+    // Verify parseEther conversion: 0.5 ETH = 500000000000000000 wei
+    const { parseEther, createPublicClient } = await import('viem');
+    const mockClient = (createPublicClient as any).mock.results.at(-1).value;
+    expect(mockClient.estimateGas).toHaveBeenCalledWith(
+      expect.objectContaining({ value: parseEther('0.5') }),
+    );
+  });
+
+  it('estimates gas with integer ETH value', async () => {
+    const estimate = await adapter.estimateGas({
+      to: '0x1234567890abcdef1234567890abcdef12345678',
+      value: '1',
+    });
+    expect(estimate.gasLimit).toBeDefined();
+    expect(estimate.gasPriceGwei).toBeDefined();
+    expect(estimate.estimatedCostEth).toBeDefined();
+
+    // Verify parseEther conversion: 1 ETH = 1000000000000000000 wei (not BigInt('1') = 1n)
+    const { parseEther, createPublicClient } = await import('viem');
+    const mockClient = (createPublicClient as any).mock.results.at(-1).value;
+    expect(mockClient.estimateGas).toHaveBeenCalledWith(
+      expect.objectContaining({ value: parseEther('1') }),
+    );
+  });
+});

--- a/packages/core/src/chain/evm-adapter.ts
+++ b/packages/core/src/chain/evm-adapter.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, createWalletClient, http, webSocket, fallback, formatEther, formatGwei, defineChain, type PublicClient, type Transport } from 'viem';
+import { createPublicClient, createWalletClient, http, webSocket, fallback, formatEther, formatGwei, parseEther, defineChain, type PublicClient, type Transport } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { getChainConfig, type ChainConfig } from './chains.js';
 import type {
@@ -121,6 +121,7 @@ export class EvmAdapter implements ChainAdapter {
         functionName: params.functionName,
         args: params.args,
         account: params.account as `0x${string}`,
+        value: params.value ? parseEther(params.value) : undefined,
       });
       return { success: true, result: result.result };
     } catch (err: any) {
@@ -158,7 +159,7 @@ export class EvmAdapter implements ChainAdapter {
   async estimateGas(params: EstimateGasParams): Promise<GasEstimate> {
     const gasLimit = await this.client.estimateGas({
       to: params.to as `0x${string}`,
-      value: BigInt(params.value || '0'),
+      value: parseEther(params.value || '0'),
       data: params.data as `0x${string}` | undefined,
     });
     const gasPrice = await this.client.getGasPrice();
@@ -217,7 +218,7 @@ export class EvmAdapter implements ChainAdapter {
         args: params.args,
         account,
         chain,
-        value: params.value ? BigInt(params.value) : undefined,
+        value: params.value ? parseEther(params.value) : undefined,
       });
 
       return { hash };

--- a/packages/core/src/chain/evm-write.test.ts
+++ b/packages/core/src/chain/evm-write.test.ts
@@ -74,3 +74,49 @@ describe('EvmAdapter - Write Operations', () => {
     expect(params.privateKey).toBe('');
   });
 });
+
+describe('EvmAdapter - Write with decimal ETH value (parseEther)', () => {
+  let adapter: EvmAdapter;
+
+  beforeEach(() => {
+    adapter = new EvmAdapter('https://rpc.example.com', 11155111);
+  });
+
+  it('writes to a contract with decimal ETH value', async () => {
+    const result = await adapter.writeContract({
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: [{ inputs: [], name: 'mint', outputs: [], stateMutability: 'payable', type: 'function' }],
+      functionName: 'mint',
+      args: [],
+      privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      value: '0.5',
+    });
+    expect(result.hash).toBe('0xWriteTxHash');
+
+    // Verify parseEther conversion: 0.5 ETH = 500000000000000000 wei
+    const { parseEther, createWalletClient } = await import('viem');
+    const mockWalletClient = (createWalletClient as any).mock.results.at(-1).value;
+    expect(mockWalletClient.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ value: parseEther('0.5') }),
+    );
+  });
+
+  it('writes to a contract with integer ETH value', async () => {
+    const result = await adapter.writeContract({
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: [{ inputs: [], name: 'mint', outputs: [], stateMutability: 'payable', type: 'function' }],
+      functionName: 'mint',
+      args: [],
+      privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      value: '1',
+    });
+    expect(result.hash).toBe('0xWriteTxHash');
+
+    // Verify parseEther conversion: 1 ETH = 1000000000000000000 wei
+    const { parseEther, createWalletClient } = await import('viem');
+    const mockWalletClient = (createWalletClient as any).mock.results.at(-1).value;
+    expect(mockWalletClient.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ value: parseEther('1') }),
+    );
+  });
+});


### PR DESCRIPTION
## Description

The MCP tool interface documents `value` as ETH-denominated decimals (e.g. `"0.5"`), but three methods in `EvmAdapter` were converting that string straight through `BigInt()`, which throws a `SyntaxError` on anything that isn't a pure integer. This PR replaces every `BigInt(params.value)` call with viem's `parseEther(params.value)` so the adapter correctly converts human-readable ETH strings into wei-denominated bigints before handing them to the RPC layer.

Closes https://github.com/stultusmundi/chainvault-mcp/issues/18

## Changes

- `packages/core/src/chain/evm-adapter.ts` — imported `parseEther` from viem; replaced `BigInt(params.value || '0')` with `parseEther(params.value || '0')` in `estimateGas` (line 162), `writeContract` (line 221), and added `value: params.value ? parseEther(params.value) : undefined` to `simulateTransaction` (line 124) which was previously ignoring the value parameter entirely.
- `packages/core/src/chain/evm-adapter.test.ts` — added a `Decimal ETH value handling (parseEther)` describe block with two tests covering `estimateGas` with `"0.5"` and `"1"`, each asserting the mock client receives the correct `parseEther`-converted bigint.
- `packages/core/src/chain/evm-write.test.ts` — added a `Write with decimal ETH value (parseEther)` describe block with two tests covering `writeContract` with `"0.5"` and `"1"`, verifying the wallet client mock receives properly converted wei values.

## Checklist

- [x] Tests added/updated (`npx vitest run`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] No secrets in code (private keys, API keys, passwords)
- [x] Commit messages follow conventions (`feat(scope): description`)
- [ ] CLAUDE.md updated if new conventions introduced
- [x] AI assistance disclosed (if applicable)

---

I touched three spots in `EvmAdapter` inside `packages/core/src/chain/evm-adapter.ts`: the `estimateGas` method around line 162 where `BigInt(params.value || '0')` became `parseEther(params.value || '0')`, the `writeContract` method around line 221 with the same `BigInt` → `parseEther` swap, and `simulateTransaction` around line 124 where I added the `value` passthrough that was missing altogether. The core idea is straightforward — the MCP tool schema tells agents that `value` is denominated in ETH (so `"0.5"` means half an ether), but `BigInt("0.5")` is a runtime crash since BigInt only accepts integer strings. `parseEther` from viem does the proper 18-decimal conversion and is already used elsewhere in the adapter (`formatEther` was imported from day one), so this keeps the dependency surface identical.

The design choice to use `parseEther` rather than, say, manually multiplying by `10**18` is intentional: viem's implementation handles edge cases around decimal precision and is already the canonical way this codebase interacts with ETH values (see `formatEther`/`formatGwei` usage in the same file). For `simulateTransaction`, the value parameter was silently dropped before this change, meaning any payable function simulation would behave as if zero ETH was sent — that's now wired through correctly. I ran `npx vitest run` locally and all 49 tests pass (including the 4 new ones), and `npx tsc --noEmit` exits cleanly with no type errors.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>