### PR TITLE
fix: V1.1 security batch (#12, #13, #14, #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+Security hardening (from a verification pass over the March review backlog):
+
+- **Path traversal (#12):** agent names are restricted to `[a-zA-Z0-9_-]` and
+  every vault path is built through a validating guard, closing an
+  arbitrary file read/write/delete via names like `../../x`.
+- **Spend-limit bypass (#13):** the rules engine now rejects non-numeric,
+  `NaN`, `Infinity`, and negative transaction values before comparison —
+  previously such values slipped past every spend limit.
+- **solc tag injection (#14):** the Docker compiler validates the solc
+  version against strict semver before it is used as an image tag.
+- **Error redaction (#16):** `sanitizeError` is now a single shared utility;
+  it redacts `cv_agent_` vault keys and bare 64+-hex private keys in addition
+  to `0x`-prefixed keys and any-scheme URLs.
+
+Deferred: #13 part B (counting deploy gas against spend limits) is a
+limit-semantics decision left for a follow-up.
+
 ## 1.0.1 — 2026-07-20
 
 - **Packaging:** CLI published as `@chainvault/mcp` (scoped; was `chainvault-mcp`).

--- a/packages/cli/src/commands/solc.test.ts
+++ b/packages/cli/src/commands/solc.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+
+vi.mock('node:child_process', () => ({ execFile: mockExecFile }));
+vi.mock('node:util', () => ({ promisify: () => mockExecFile }));
+
+import { pullSolc } from './solc.js';
+
+describe('pullSolc', () => {
+  it('rejects a non-semver version before invoking docker', async () => {
+    for (const bad of ['latest', '-v', '0.8', '0.8.24; echo pwned', 'ethereum/solc@sha256:abcd']) {
+      await expect(pullSolc(bad)).rejects.toThrow(/invalid solc version/i);
+    }
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('invokes docker pull for a well-formed version', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    const msg = await pullSolc('0.8.24');
+    expect(msg).toMatch(/ethereum\/solc:0\.8\.24/);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'docker',
+      ['pull', 'ethereum/solc:0.8.24'],
+      expect.anything(),
+    );
+  });
+});

--- a/packages/cli/src/commands/solc.ts
+++ b/packages/cli/src/commands/solc.ts
@@ -1,9 +1,11 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
+import { assertValidSolcVersion } from '@chainvault/core';
 
 const execFileAsync = promisify(execFileCb);
 
 export async function pullSolc(version: string = '0.8.20'): Promise<string> {
+  assertValidSolcVersion(version);
   const image = `ethereum/solc:${version}`;
   console.log(`Pulling Docker image: ${image}...`);
 

--- a/packages/core/src/compiler/solidity.test.ts
+++ b/packages/core/src/compiler/solidity.test.ts
@@ -156,6 +156,20 @@ describe('resolveCompiler', () => {
   });
 });
 
+describe('resolveCompiler version validation', () => {
+  it('rejects a non-semver version before touching docker or solc', async () => {
+    for (const bad of ['latest', '-v', '0.8', '0.8.x', '0.8.24; rm -rf /', 'ethereum/solc@sha256:abcd', ' 0.8.24']) {
+      await expect(resolveCompiler(bad)).rejects.toThrow(/invalid solc version/i);
+    }
+  });
+
+  it('accepts a well-formed semver version', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' }); // docker info
+    const method = await resolveCompiler('0.8.24');
+    expect(method).toEqual({ type: 'docker', version: '0.8.24' });
+  });
+});
+
 describe('compile', () => {
   beforeEach(() => {
     mockExecFile.mockReset();

--- a/packages/core/src/compiler/solidity.ts
+++ b/packages/core/src/compiler/solidity.ts
@@ -67,6 +67,17 @@ export interface CompilerMethod {
   version: string;
 }
 
+// solc version flows into a Docker image tag (`ethereum/solc:<version>`) and a
+// solc CLI comparison. Require strict semver so it can't inject docker flags,
+// alternate tags, or `@sha256:` digests that redirect which image runs.
+const SOLC_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+export function assertValidSolcVersion(version: string): void {
+  if (!SOLC_VERSION_PATTERN.test(version)) {
+    throw new Error(`Invalid solc version: ${JSON.stringify(version)} (expected e.g. "0.8.24")`);
+  }
+}
+
 export function buildStandardInput(
   source: string,
   optimization: boolean = false,
@@ -129,6 +140,7 @@ export function parseOutput(rawOutput: string, contractName: string): CompileRes
 }
 
 export async function resolveCompiler(version: string): Promise<CompilerMethod> {
+  assertValidSolcVersion(version);
   // Try docker first (with timeout to avoid hanging when Docker Desktop is installed but not running)
   try {
     await execFileAsync('docker', ['info'], { timeout: 5000 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,7 +49,7 @@ export { AuditStore } from './db/audit-store.js';
 export type { AuditEntry } from './db/audit-store.js';
 
 // Compiler
-export { compile, buildStandardInput, parseOutput, resolveCompiler } from './compiler/solidity.js';
+export { compile, buildStandardInput, parseOutput, resolveCompiler, assertValidSolcVersion } from './compiler/solidity.js';
 export type { CompileResult, CompilerMethod } from './compiler/solidity.js';
 
 // Auth / WebAuthn

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -5,24 +5,14 @@ import { EvmAdapter } from '../../chain/evm-adapter.js';
 import { getChainConfig } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
+import { sanitizeError } from './sanitize.js';
 
 type ContextGetter = () => AgentContext | null;
 const noop: AuditFn = () => {};
 
-/**
- * Strips potential key material from error messages before returning to agents.
- * Redacts anything that looks like a private key (0x + 64 hex chars), then
- * redacts any URL — viem embeds the full request URL (which for custom vault
- * RPC endpoints can carry provider API keys, e.g. .../v3/<key>) into error
- * messages such as HttpRequestError, and this must never reach an agent-visible
- * tool response or an audit row.
- */
-export function sanitizeError(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg
-    .replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]')
-    .replace(/[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi, 'https://[REDACTED]');
-}
+// Re-exported for tests and older importers; the implementation is shared so
+// the redaction rules never drift between tool files.
+export { sanitizeError };
 
 /**
  * JSON.stringify cannot serialize bigint, but viem returns raw bigint values

--- a/packages/core/src/mcp/tools/compiler-tools.ts
+++ b/packages/core/src/mcp/tools/compiler-tools.ts
@@ -2,15 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AuditFn } from '../audit-fn.js';
 import { compile } from '../../compiler/solidity.js';
-
-/**
- * Strips potential key material from error messages before returning to agents.
- * Redacts anything that looks like a private key (0x + 64 hex chars).
- */
-function sanitizeError(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
-}
+import { sanitizeError } from './sanitize.js';
 
 const noop: AuditFn = () => {};
 

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -4,20 +4,12 @@ import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
 import { getChainConfig } from '../../chain/chains.js';
 import { ApiProxy } from '../../proxy/api-proxy.js';
+import { sanitizeError } from './sanitize.js';
 
 type ContextGetter = () => AgentContext | null;
 
 const proxy = new ApiProxy();
 const noop: AuditFn = () => {};
-
-/**
- * Strips potential key material from error messages before returning to agents.
- * Redacts anything that looks like a private key (0x + 64 hex chars).
- */
-function sanitizeError(err: unknown): string {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg.replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]');
-}
 
 export function registerProxyTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
   server.registerTool(

--- a/packages/core/src/mcp/tools/sanitize.test.ts
+++ b/packages/core/src/mcp/tools/sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeError } from './sanitize.js';
+
+const PRIV = 'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'; // 64 hex
+const VAULT_KEY = 'cv_agent_' + 'a'.repeat(64);
+const PUBLIC_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'; // 40 hex — not secret
+
+describe('sanitizeError (shared)', () => {
+  it('redacts a 0x-prefixed private key', () => {
+    const out = sanitizeError(new Error(`signing failed with key 0x${PRIV}`));
+    expect(out).not.toContain(PRIV);
+    expect(out).toContain('0x[REDACTED]');
+  });
+
+  it('redacts a bare 64-hex private key with no 0x prefix', () => {
+    const out = sanitizeError(new Error(`raw key ${PRIV} leaked`));
+    expect(out).not.toContain(PRIV);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts a cv_agent_ vault key', () => {
+    const out = sanitizeError(`bad vault key ${VAULT_KEY}`);
+    expect(out).not.toContain('a'.repeat(64));
+    expect(out).toContain('cv_agent_[REDACTED]');
+  });
+
+  it('redacts URLs of any scheme (embedded credentials)', () => {
+    expect(sanitizeError('at https://mainnet.infura.io/v3/SECRETKEY123')).not.toContain('SECRETKEY123');
+    expect(sanitizeError('at wss://node.example.com/ws/WSTOKEN')).not.toContain('WSTOKEN');
+  });
+
+  it('does not redact a public 40-hex address', () => {
+    const out = sanitizeError(new Error(`revert from ${PUBLIC_ADDRESS}`));
+    expect(out).toContain(PUBLIC_ADDRESS);
+  });
+
+  it('handles both Error and string inputs', () => {
+    expect(sanitizeError(new Error('plain'))).toBe('plain');
+    expect(sanitizeError('plain')).toBe('plain');
+  });
+});

--- a/packages/core/src/mcp/tools/sanitize.test.ts
+++ b/packages/core/src/mcp/tools/sanitize.test.ts
@@ -29,6 +29,13 @@ describe('sanitizeError (shared)', () => {
     expect(sanitizeError('at wss://node.example.com/ws/WSTOKEN')).not.toContain('WSTOKEN');
   });
 
+  it('redacts private keys even when contiguous with more hex (no delimiter)', () => {
+    const out = sanitizeError(`leak ${PRIV}${PRIV}`); // 128 contiguous hex, no 0x
+    expect(out).not.toContain(PRIV);
+    const out2 = sanitizeError(`sig 0x${PRIV}${PRIV}aa`); // 0x + 130 hex
+    expect(out2).not.toContain(PRIV);
+  });
+
   it('does not redact a public 40-hex address', () => {
     const out = sanitizeError(new Error(`revert from ${PUBLIC_ADDRESS}`));
     expect(out).toContain(PUBLIC_ADDRESS);

--- a/packages/core/src/mcp/tools/sanitize.ts
+++ b/packages/core/src/mcp/tools/sanitize.ts
@@ -1,0 +1,22 @@
+/**
+ * Redacts secrets from error text before it reaches an agent or the audit log.
+ * Shared by every MCP tool so the redaction rules never drift between copies.
+ *
+ * Covers:
+ *  - cv_agent_ vault keys
+ *  - private keys: 0x-prefixed and bare 64-hex
+ *  - URLs of any scheme (http/https/ws/wss/...), which commonly embed RPC or
+ *    API credentials in the path or query string
+ *
+ * Not covered: a bare alphanumeric API key that appears outside a URL cannot be
+ * distinguished from ordinary text by pattern alone, so it is not redacted here.
+ * Public 40-hex addresses are intentionally left intact.
+ */
+export function sanitizeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg
+    .replace(/cv_agent_[a-fA-F0-9]+/g, 'cv_agent_[REDACTED]')
+    .replace(/[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi, 'https://[REDACTED]')
+    .replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]')
+    .replace(/(?<![a-fA-F0-9])[a-fA-F0-9]{64}(?![a-fA-F0-9])/g, '[REDACTED]');
+}

--- a/packages/core/src/mcp/tools/sanitize.ts
+++ b/packages/core/src/mcp/tools/sanitize.ts
@@ -4,19 +4,21 @@
  *
  * Covers:
  *  - cv_agent_ vault keys
- *  - private keys: 0x-prefixed and bare 64-hex
+ *  - private keys: 0x-prefixed and any run of 64+ hex chars (which also catches
+ *    keys concatenated to adjacent hex with no delimiter). This can over-redact
+ *    long hashes/bytecode in error text, which is acceptable for an error-only
+ *    sanitizer. Public 40-hex addresses (< 64) are intentionally left intact.
  *  - URLs of any scheme (http/https/ws/wss/...), which commonly embed RPC or
  *    API credentials in the path or query string
  *
  * Not covered: a bare alphanumeric API key that appears outside a URL cannot be
  * distinguished from ordinary text by pattern alone, so it is not redacted here.
- * Public 40-hex addresses are intentionally left intact.
  */
 export function sanitizeError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
   return msg
     .replace(/cv_agent_[a-fA-F0-9]+/g, 'cv_agent_[REDACTED]')
     .replace(/[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi, 'https://[REDACTED]')
-    .replace(/0x[a-fA-F0-9]{64}/g, '0x[REDACTED]')
-    .replace(/(?<![a-fA-F0-9])[a-fA-F0-9]{64}(?![a-fA-F0-9])/g, '[REDACTED]');
+    .replace(/0x[a-fA-F0-9]{64,}/g, '0x[REDACTED]')
+    .replace(/(?<![a-fA-F0-9])[a-fA-F0-9]{64,}/g, '[REDACTED]');
 }

--- a/packages/core/src/rules/engine.test.ts
+++ b/packages/core/src/rules/engine.test.ts
@@ -51,6 +51,25 @@ describe('RulesEngine', () => {
       expect(result.approved).toBe(true);
     });
 
+    it('denies non-numeric, NaN, Infinity, and negative values (no limit bypass)', () => {
+      const engine = new RulesEngine(DEPLOYER_CONFIG);
+      for (const value of ['NaN', 'abc', 'Infinity', '-Infinity', '-1', '-0.5', '']) {
+        const result = engine.checkTxRequest({ type: 'write', chain_id: 11155111, value });
+        expect(result.approved, `value ${JSON.stringify(value)} must be denied`).toBe(false);
+      }
+    });
+
+    it('denies a non-numeric value even when no limits are configured', () => {
+      // READER can only read/simulate; use a config with a spend-incurring type but no limits.
+      const noLimits: AgentConfig = {
+        ...DEPLOYER_CONFIG,
+        tx_rules: { allowed_types: ['deploy', 'write', 'read', 'simulate'], limits: {} },
+      };
+      const engine = new RulesEngine(noLimits);
+      const result = engine.checkTxRequest({ type: 'write', chain_id: 11155111, value: 'NaN' });
+      expect(result.approved).toBe(false);
+    });
+
     it('denies request for unauthorized chain', () => {
       const engine = new RulesEngine(DEPLOYER_CONFIG);
       const result = engine.checkTxRequest({

--- a/packages/core/src/rules/engine.ts
+++ b/packages/core/src/rules/engine.ts
@@ -59,7 +59,14 @@ export class RulesEngine {
 
     // 4. Check spend limits (skip for read/simulate)
     if (request.type !== 'read' && request.type !== 'simulate') {
-      const limitResult = this.checkSpendLimits(request.chain_id, parseFloat(request.value));
+      // Reject non-numeric / NaN / Infinity / negative values before any
+      // comparison. Otherwise NaN makes every `>` check false and silently
+      // bypasses all spend limits (the control that runs before decryption).
+      const value = parseFloat(request.value);
+      if (!Number.isFinite(value) || value < 0) {
+        return { approved: false, reason: `Invalid transaction value: ${JSON.stringify(request.value)}` };
+      }
+      const limitResult = this.checkSpendLimits(request.chain_id, value);
       if (!limitResult.approved) return limitResult;
     }
 

--- a/packages/core/src/vault/agent-vault.test.ts
+++ b/packages/core/src/vault/agent-vault.test.ts
@@ -150,6 +150,48 @@ describe('AgentVaultManager', () => {
     });
   });
 
+  describe('path traversal protection', () => {
+    // Match the guard's error specifically, so these fail on ENOENT/decrypt
+    // errors and only pass once name validation actually fires.
+    const INVALID = /invalid agent name/i;
+    const EVIL = '../../evil-agent';
+    const DUMMY_KEY = 'cv_agent_' + '0'.repeat(64);
+
+    it('createAgent rejects a config name with path separators', async () => {
+      const manager = new AgentVaultManager(testDir, masterVault);
+      const evilConfig: AgentConfig = { ...DEPLOYER_CONFIG, name: EVIL };
+      await expect(manager.createAgent(evilConfig, [], [])).rejects.toThrow(INVALID);
+    });
+
+    it('openAgentVault rejects a traversing agent name', async () => {
+      const manager = new AgentVaultManager(testDir, masterVault);
+      await expect(manager.openAgentVault(EVIL, DUMMY_KEY)).rejects.toThrow(INVALID);
+    });
+
+    it('revokeAgent rejects a traversing name and performs no arbitrary delete', async () => {
+      const manager = new AgentVaultManager(testDir, masterVault);
+      // Plant a file at the traversal target; revoke must not delete it.
+      const { writeFile } = await import('node:fs/promises');
+      const { existsSync } = await import('node:fs');
+      const victim = join(testDir, 'victim.vault');
+      await writeFile(victim, 'precious', 'utf8');
+      await expect(manager.revokeAgent('../victim')).rejects.toThrow(INVALID);
+      expect(existsSync(victim)).toBe(true);
+    });
+
+    it('rotateAgentKey rejects a traversing agent name', async () => {
+      const manager = new AgentVaultManager(testDir, masterVault);
+      await expect(manager.rotateAgentKey(EVIL, DUMMY_KEY)).rejects.toThrow(INVALID);
+    });
+
+    it('regenerateAgent rejects a traversing agent name', async () => {
+      const manager = new AgentVaultManager(testDir, masterVault);
+      await expect(
+        manager.regenerateAgent(EVIL, DUMMY_KEY, [], []),
+      ).rejects.toThrow(INVALID);
+    });
+  });
+
   describe('listAgents', () => {
     it('lists all agents with summaries', async () => {
       const manager = new AgentVaultManager(testDir, masterVault);

--- a/packages/core/src/vault/agent-vault.ts
+++ b/packages/core/src/vault/agent-vault.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { encrypt, decrypt, generateVaultKeyString, wipeBuffer } from './crypto.js';
-import { AgentVaultDataSchema, type AgentVaultData, type AgentConfig } from './types.js';
+import { AGENT_NAME_PATTERN, AgentVaultDataSchema, type AgentVaultData, type AgentConfig } from './types.js';
 import type { MasterVault } from './master-vault.js';
 
 const AGENTS_DIR = 'agents';
@@ -15,11 +15,25 @@ export class AgentVaultManager {
     this.masterVault = masterVault;
   }
 
+  /**
+   * Validates an agent name and returns its vault file path. Callers pass the
+   * name straight in (bypassing schema validation), so this is the enforcement
+   * point that prevents path traversal (arbitrary read/write/delete).
+   */
+  private vaultPathFor(agentName: string): string {
+    if (!AGENT_NAME_PATTERN.test(agentName)) {
+      throw new Error(`Invalid agent name: ${JSON.stringify(agentName)}`);
+    }
+    return join(this.basePath, AGENTS_DIR, `${agentName}.vault`);
+  }
+
   async createAgent(
     config: AgentConfig,
     grantedKeys: string[],
     grantedApiKeys: string[],
   ): Promise<{ vaultKey: string }> {
+    // Validate the name before any state mutation or disk write.
+    const vaultPath = this.vaultPathFor(config.name);
     const masterData = this.masterVault.getData();
 
     // Store agent config in master vault
@@ -62,9 +76,8 @@ export class AgentVaultManager {
     const { keyString, keyBuffer } = generateVaultKeyString();
     const encrypted = encrypt(JSON.stringify(agentVaultData), keyBuffer);
 
-    const agentsDir = join(this.basePath, AGENTS_DIR);
-    await mkdir(agentsDir, { recursive: true });
-    await writeFile(join(agentsDir, `${config.name}.vault`), encrypted, 'utf8');
+    await mkdir(join(this.basePath, AGENTS_DIR), { recursive: true });
+    await writeFile(vaultPath, encrypted, 'utf8');
     wipeBuffer(keyBuffer);
 
     return { vaultKey: keyString };
@@ -74,13 +87,11 @@ export class AgentVaultManager {
     agentName: string,
     vaultKey: string,
   ): Promise<AgentVaultData> {
+    const vaultPath = this.vaultPathFor(agentName);
     const hexPart = vaultKey.replace('cv_agent_', '');
     const keyBuffer = Buffer.from(hexPart, 'hex');
 
-    const encrypted = await readFile(
-      join(this.basePath, AGENTS_DIR, `${agentName}.vault`),
-      'utf8',
-    );
+    const encrypted = await readFile(vaultPath, 'utf8');
     const decrypted = decrypt(encrypted, keyBuffer);
     wipeBuffer(keyBuffer);
     return AgentVaultDataSchema.parse(JSON.parse(decrypted));
@@ -97,11 +108,7 @@ export class AgentVaultManager {
     const { keyString, keyBuffer } = generateVaultKeyString();
     const encrypted = encrypt(JSON.stringify(agentData), keyBuffer);
 
-    await writeFile(
-      join(this.basePath, AGENTS_DIR, `${agentName}.vault`),
-      encrypted,
-      'utf8',
-    );
+    await writeFile(this.vaultPathFor(agentName), encrypted, 'utf8');
     wipeBuffer(keyBuffer);
 
     return { vaultKey: keyString };
@@ -150,13 +157,13 @@ export class AgentVaultManager {
     const encrypted = encrypt(JSON.stringify(agentVaultData), keyBuffer);
     wipeBuffer(keyBuffer);
 
-    await writeFile(join(this.basePath, AGENTS_DIR, `${agentName}.vault`), encrypted, 'utf8');
+    await writeFile(this.vaultPathFor(agentName), encrypted, 'utf8');
 
     return { vaultKey: keyString };
   }
 
   async revokeAgent(agentName: string): Promise<void> {
-    const vaultPath = join(this.basePath, AGENTS_DIR, `${agentName}.vault`);
+    const vaultPath = this.vaultPathFor(agentName);
     await rm(vaultPath, { force: true });
 
     const masterData = this.masterVault.getData();

--- a/packages/core/src/vault/types.test.ts
+++ b/packages/core/src/vault/types.test.ts
@@ -90,6 +90,52 @@ describe('AgentConfigSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('accepts names with safe filesystem characters', () => {
+    for (const name of ['deployer', 'agent_1', 'read-only', 'A9']) {
+      const result = AgentConfigSchema.safeParse({
+        name,
+        chains: [1],
+        tx_rules: { allowed_types: ['read'], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects names containing path separators or traversal sequences', () => {
+    for (const name of ['../evil', '../../etc/passwd', 'a/b', 'a\\b', 'foo.vault', 'has space', '.', '']) {
+      const result = AgentConfigSchema.safeParse({
+        name,
+        chains: [1],
+        tx_rules: { allowed_types: ['read'], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' },
+      });
+      expect(result.success, `name ${JSON.stringify(name)} should be rejected`).toBe(false);
+    }
+  });
+});
+
+describe('AgentVaultDataSchema', () => {
+  it('rejects an agent_name containing path traversal', () => {
+    const result = AgentVaultDataSchema.safeParse({
+      version: 1,
+      agent_name: '../../evil',
+      config: {
+        name: 'deployer',
+        chains: [1],
+        tx_rules: { allowed_types: ['read'], limits: {} },
+        api_access: {},
+        contract_rules: { mode: 'none' },
+      },
+      keys: {},
+      api_keys: {},
+      rpc_endpoints: {},
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('MasterVaultDataSchema', () => {

--- a/packages/core/src/vault/types.ts
+++ b/packages/core/src/vault/types.ts
@@ -40,8 +40,12 @@ const ContractRulesSchema = z.discriminatedUnion('mode', [
 
 // --- Agent Config ---
 
+// Agent names are used to build vault filenames (`<name>.vault`), so they must
+// not contain path separators or traversal sequences. Restrict to a safe set.
+export const AGENT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 export const AgentConfigSchema = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).regex(AGENT_NAME_PATTERN),
   chains: z.array(z.number().int()),
   tx_rules: TxRulesSchema,
   api_access: z.record(z.string(), ApiAccessRuleSchema),
@@ -86,7 +90,7 @@ export type MasterVaultData = z.infer<typeof MasterVaultDataSchema>;
 
 export const AgentVaultDataSchema = z.object({
   version: z.literal(1),
-  agent_name: z.string(),
+  agent_name: z.string().min(1).regex(AGENT_NAME_PATTERN),
   config: AgentConfigSchema,
   keys: z.record(z.string(), StoredKeySchema),
   api_keys: z.record(z.string(), StoredApiKeySchema),


### PR DESCRIPTION
## V1.1 security batch

Fixes four issues from the March security-review backlog, each verified to still
reproduce at v1.0.1 before fixing. Every fix is test-first (a test that fails on
the old code, then the fix), committed atomically.

| Issue | Fix |
|-------|-----|
| **#12** path traversal via agent name | Restrict names to `[a-zA-Z0-9_-]` in `AgentConfigSchema` + `AgentVaultDataSchema`, and route all five `AgentVaultManager` methods through a `vaultPathFor()` guard. Closes arbitrary file read/write/delete (`revokeAgent('../x')` etc.). |
| **#13 (part A)** spend-limit bypass via NaN | Rules engine rejects non-numeric / `NaN` / `Infinity` / negative values before comparison. Previously `NaN > limit` was always false, silently bypassing every limit. |
| **#14** solc Docker tag injection | `assertValidSolcVersion()` (strict semver) in `resolveCompiler` and CLI `pullSolc` before the version reaches the `ethereum/solc:<version>` image tag. |
| **#16** error-sanitization gaps | One shared `sanitizeError`; adds `cv_agent_` vault-key and bare 64+-hex private-key redaction, and fixes the two copies that lacked URL redaction. |

Closes #12, #13, #14, #16. #22 was closed as a duplicate of #13.

### Not included (deliberate)
**#13 part B** — `deploy_contract` records zero spend, so deploys don't count
against limits. Counting gas against value-denominated limits (and whether that
applies to writes too) is a limit-*semantics* decision that changes behavior for
existing configs, so it's left for a follow-up rather than baked in here.

### Verification
- 437 unit tests pass (+21 new); `tsc --noEmit` clean.
- Adversarial security review of the whole branch: no Critical/Important
  findings. One Minor finding (a private key glued to adjacent hex with no
  delimiter escaping redaction) was fixed in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
