### PR TITLE
fix: make the type-check real — tame registerTool OOM, fix hidden errors (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
-      - run: npx tsc --noEmit
+      - run: npm run lint
       - run: npm run build
       - run: npx vitest run --project unit
   workstyle:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Secure MCP server gateway between AI agents and EVM blockchains with vault-based
 
 **Build & Type Check:**
 - Build: `npm run build`
-- Type check: `npx tsc --noEmit`
+- Type check: `npm run lint` (`tsc -p tsconfig.check.json --noEmit` — checks both packages; plain `tsc --noEmit` is vacuous here)
 
 **Test Tiers (see CONTRIBUTING.md for details):**
 - Unit (PR gate, offline): `npx vitest run --project unit`

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:fork": "WORKSTYLE_FORK=1 vitest run --project fork",
     "test:testnet": "vitest run --project testnet",
     "test:scenarios": "npm run build && tsx tests/agent-e2e/run-scenarios.ts",
-    "lint": "tsc --noEmit",
+    "lint": "tsc -p tsconfig.check.json --noEmit",
     "chainvault": "node packages/cli/dist/index.js",
     "serve": "node packages/cli/dist/index.js serve"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:fork": "WORKSTYLE_FORK=1 vitest run --project fork",
     "test:testnet": "vitest run --project testnet",
     "test:scenarios": "npm run build && tsx tests/agent-e2e/run-scenarios.ts",
-    "lint": "tsc -p tsconfig.check.json --noEmit",
+    "lint": "tsc -p tsconfig.check.json --noEmit && tsc -p tsconfig.check.tests.json --noEmit",
     "chainvault": "node packages/cli/dist/index.js",
     "serve": "node packages/cli/dist/index.js serve"
   },

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -11,6 +11,10 @@ MCP server core with vault, rules, chain, proxy, and audit modules.
 - `audit/` — Append-only logger. Standalone, no vault imports
 - `mcp/` — Wires all modules together. Only module allowed to import from all others
 
+## MCP Tool Registration
+
+- Register every tool via the `registerTool` wrapper in `mcp/tools/register.ts`, NEVER `server.registerTool` directly. The SDK's generic infers handler args from the Zod schema and sends type instantiation infinitely deep (`TS2589`), which OOMs `tsc`. The wrapper types the handler itself and contains that inference (issue #33).
+
 ## Encryption Standards
 
 - AES-256-GCM for all encryption (12-byte IV, 16-byte auth tag)

--- a/packages/core/src/chain/faucet.test.ts
+++ b/packages/core/src/chain/faucet.test.ts
@@ -90,6 +90,41 @@ describe('requestFaucet', () => {
     expect(result.success).toBe(true);
     expect(result.txHash).toBe('0xtxhash');
   });
+
+  it('ignores a non-string txHash from a malformed or hostile faucet', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ txHash: { evil: 'object' } }),
+    });
+
+    const result = await requestFaucet(11155111, '0x1234');
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBeUndefined();
+    // The bogus value must never reach the agent-visible message.
+    expect(result.message).not.toContain('[object Object]');
+  });
+
+  it('ignores a numeric txHash', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hash: 12345 }),
+    });
+
+    const result = await requestFaucet(11155111, '0x1234');
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBeUndefined();
+  });
+
+  it('handles a non-object JSON body without crashing', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => 'not-an-object',
+    });
+
+    const result = await requestFaucet(11155111, '0x1234');
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBeUndefined();
+  });
 });
 
 describe('getFaucetInfo', () => {

--- a/packages/core/src/chain/faucet.ts
+++ b/packages/core/src/chain/faucet.ts
@@ -65,6 +65,23 @@ export async function requestFaucet(
   };
 }
 
+/**
+ * Safely pulls a transaction hash out of an untrusted faucet JSON response.
+ * The response body is `unknown` — a hostile or buggy faucet could return a
+ * non-object, or a non-string hash — so we accept only a non-empty string from
+ * the known field names and ignore anything else. This keeps bogus values
+ * (e.g. `[object Object]`) out of the agent-visible result message.
+ */
+function extractTxHash(data: unknown): string | undefined {
+  if (typeof data !== 'object' || data === null) return undefined;
+  const record = data as Record<string, unknown>;
+  for (const field of ['txHash', 'hash', 'transactionHash'] as const) {
+    const value = record[field];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
 async function tryApiFaucet(
   faucet: FaucetConfig,
   address: string,
@@ -90,8 +107,8 @@ async function tryApiFaucet(
       };
     }
 
-    const data = await response.json();
-    const txHash = data.txHash || data.hash || data.transactionHash || undefined;
+    const data: unknown = await response.json();
+    const txHash = extractTxHash(data);
 
     return {
       success: true,

--- a/packages/core/src/chain/types.ts
+++ b/packages/core/src/chain/types.ts
@@ -5,14 +5,14 @@ export interface BalanceResult {
 
 export interface ReadContractParams {
   address: string;
-  abi: any[];
+  abi: readonly any[];
   functionName: string;
   args: any[];
 }
 
 export interface SimulateParams {
   address: string;
-  abi: any[];
+  abi: readonly any[];
   functionName: string;
   args: any[];
   account: string;
@@ -27,7 +27,7 @@ export interface SimulateResult {
 
 export interface EventParams {
   address: string;
-  abi: any[];
+  abi: readonly any[];
   eventName: string;
   fromBlock?: bigint;
   toBlock?: bigint;
@@ -59,7 +59,7 @@ export interface EstimateGasParams {
 }
 
 export interface DeployParams {
-  abi: any[];
+  abi: readonly any[];
   bytecode: string;
   args?: any[];
   privateKey: string;
@@ -67,7 +67,7 @@ export interface DeployParams {
 
 export interface WriteContractParams {
   address: string;
-  abi: any[];
+  abi: readonly any[];
   functionName: string;
   args: any[];
   privateKey: string;

--- a/packages/core/src/mcp/tools/chain-registry-tools.ts
+++ b/packages/core/src/mcp/tools/chain-registry-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
 import type { AuditFn } from '../audit-fn.js';
 import type { AgentContext } from '../context.js';
 import { SUPPORTED_CHAINS, getChainConfig, getChainsWithFaucets } from '../../chain/chains.js';
@@ -10,7 +11,7 @@ const noop: AuditFn = () => {};
 const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
 
 export function registerChainRegistryTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
-  server.registerTool(
+  registerTool(server,
     'list_supported_chains',
     {
       title: 'List Supported Chains',
@@ -44,7 +45,7 @@ export function registerChainRegistryTools(server: McpServer, getContext: Contex
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'request_faucet',
     {
       title: 'Request Testnet Funds',

--- a/packages/core/src/mcp/tools/chain-tools.test.ts
+++ b/packages/core/src/mcp/tools/chain-tools.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerChainTools, sanitizeError } from './chain-tools.js';
 import type { AgentContext } from '../context.js';
+import type { SimulateResult } from '../../chain/types.js';
 
-const writeContractMock = vi.fn(async () => ({ hash: '0xWriteTxHash' }));
-const simulateTransactionMock = vi.fn(async () => ({ success: true, result: null }));
+// Typed to the adapter params the handlers actually pass, so `.mock.calls`
+// carries real argument types (otherwise the args tuple infers as `[]`).
+const writeContractMock = vi.fn(async (_params: { value?: string }) => ({ hash: '0xWriteTxHash' }));
+const simulateTransactionMock = vi.fn(
+  async (_params: { value?: string }): Promise<SimulateResult> => ({ success: true, result: null }),
+);
 
 vi.mock('../../chain/evm-adapter.js', () => ({
   EvmAdapter: {

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { parseEther } from 'viem';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
 import { EvmAdapter } from '../../chain/evm-adapter.js';
 import { getChainConfig } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
@@ -54,7 +55,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
   // Tier 2 write tools
   // ---------------------------------------------------------------------------
 
-  server.registerTool(
+  registerTool(server,
     'deploy_contract',
     {
       title: 'Deploy Smart Contract',
@@ -105,7 +106,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'interact_contract',
     {
       title: 'Write to Smart Contract',
@@ -160,7 +161,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'verify_contract',
     {
       title: 'Verify Contract Source',
@@ -228,7 +229,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
   // Tier 1 wired tools
   // ---------------------------------------------------------------------------
 
-  server.registerTool(
+  registerTool(server,
     'get_balance',
     {
       title: 'Get Balance',
@@ -258,7 +259,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'get_contract_state',
     {
       title: 'Read Contract State',
@@ -297,7 +298,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'simulate_transaction',
     {
       title: 'Simulate Transaction',
@@ -353,7 +354,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'get_events',
     {
       title: 'Get Contract Events',
@@ -394,7 +395,7 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'get_transaction',
     {
       title: 'Get Transaction Details',

--- a/packages/core/src/mcp/tools/compiler-tools.ts
+++ b/packages/core/src/mcp/tools/compiler-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
 import type { AuditFn } from '../audit-fn.js';
 import { compile } from '../../compiler/solidity.js';
 import { sanitizeError } from './sanitize.js';
@@ -7,7 +8,7 @@ import { sanitizeError } from './sanitize.js';
 const noop: AuditFn = () => {};
 
 export function registerCompilerTools(server: McpServer, audit: AuditFn = noop): void {
-  server.registerTool(
+  registerTool(server,
     'compile_contract',
     {
       title: 'Compile Solidity Contract',

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
 import { getChainConfig } from '../../chain/chains.js';
@@ -12,7 +13,7 @@ const proxy = new ApiProxy();
 const noop: AuditFn = () => {};
 
 export function registerProxyTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
-  server.registerTool(
+  registerTool(server,
     'query_explorer',
     {
       title: 'Query Block Explorer',
@@ -75,7 +76,7 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'query_price',
     {
       title: 'Get Token Price',

--- a/packages/core/src/mcp/tools/register.test.ts
+++ b/packages/core/src/mcp/tools/register.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
+
+describe('registerTool wrapper', () => {
+  it('forwards name, definition, and handler to server.registerTool unchanged', () => {
+    const registerToolSpy = vi.fn();
+    const fakeServer = { registerTool: registerToolSpy } as unknown as McpServer;
+    const def = {
+      title: 'My Tool',
+      description: 'Does a thing',
+      inputSchema: z.object({ x: z.number() }),
+    };
+    const handler = async () => ({ content: [{ type: 'text' as const, text: 'ok' }] });
+
+    registerTool(fakeServer, 'my_tool', def, handler);
+
+    expect(registerToolSpy).toHaveBeenCalledTimes(1);
+    expect(registerToolSpy).toHaveBeenCalledWith('my_tool', def, handler);
+  });
+
+  it('invokes the handler with parsed args when the tool is called', async () => {
+    let received: unknown;
+    const fakeServer = {
+      registerTool: (_name: string, _def: unknown, handler: (a: unknown) => unknown) => {
+        received = handler;
+      },
+    } as unknown as McpServer;
+
+    const handler = async ({ chain_id }: { chain_id: number }) => ({
+      content: [{ type: 'text' as const, text: String(chain_id) }],
+    });
+
+    registerTool(
+      fakeServer,
+      'echo',
+      { title: 'Echo', description: 'echo', inputSchema: z.object({ chain_id: z.number() }) },
+      handler,
+    );
+
+    const result = await (received as typeof handler)({ chain_id: 42 });
+    expect(result.content[0].text).toBe('42');
+  });
+});

--- a/packages/core/src/mcp/tools/register.ts
+++ b/packages/core/src/mcp/tools/register.ts
@@ -1,0 +1,47 @@
+import type { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * A tool definition as accepted by the MCP SDK's `registerTool`.
+ * `inputSchema` is a Zod object; its inferred output types the handler args.
+ */
+interface ToolDefinition<Schema extends z.AnyZodObject> {
+  title: string;
+  description: string;
+  inputSchema: Schema;
+}
+
+/**
+ * Typed wrapper over `McpServer.registerTool`.
+ *
+ * The SDK's `registerTool` is generic over the tool's Zod schema and infers the
+ * handler's argument type from it. With our schemas that inference recurses
+ * without bound (`TS2589: Type instantiation is excessively deep`) and makes
+ * `tsc` consume >8 GB and crash — which is why the project's type-check was
+ * disabled and became vacuous (issue #33).
+ *
+ * We do the inference ourselves — `z.infer<Schema>` is a single, bounded
+ * instantiation of our own object schema — and hand the SDK an already-typed
+ * callback through one contained cast. The SDK's runaway generic is never
+ * instantiated. Runtime behavior is identical to calling `server.registerTool`
+ * directly; only the type-level cost changes.
+ *
+ * Every MCP tool registration MUST go through this wrapper rather than calling
+ * `server.registerTool` directly, or the type-check will OOM again.
+ */
+export function registerTool<Schema extends z.AnyZodObject>(
+  server: McpServer,
+  name: string,
+  definition: ToolDefinition<Schema>,
+  handler: (args: z.infer<Schema>) => Promise<CallToolResult>,
+): void {
+  const untyped = server as unknown as {
+    registerTool: (
+      name: string,
+      definition: unknown,
+      handler: unknown,
+    ) => unknown;
+  };
+  untyped.registerTool(name, definition, handler);
+}

--- a/packages/core/src/mcp/tools/vault-tools.ts
+++ b/packages/core/src/mcp/tools/vault-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTool } from './register.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
 import { getChainConfig } from '../../chain/chains.js';
@@ -9,7 +10,7 @@ type ContextGetter = () => AgentContext | null;
 const noop: AuditFn = () => {};
 
 export function registerVaultTools(server: McpServer, getContext: ContextGetter, audit: AuditFn = noop): void {
-  server.registerTool(
+  registerTool(server,
     'list_chains',
     {
       title: 'List Accessible Chains',
@@ -41,7 +42,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'list_capabilities',
     {
       title: 'List Agent Capabilities',
@@ -68,7 +69,7 @@ export function registerVaultTools(server: McpServer, getContext: ContextGetter,
     },
   );
 
-  server.registerTool(
+  registerTool(server,
     'get_agent_address',
     {
       title: 'Get Agent Wallet Address',

--- a/tests/agent-e2e/claude-agent-sdk.d.ts
+++ b/tests/agent-e2e/claude-agent-sdk.d.ts
@@ -62,10 +62,24 @@ declare module '@anthropic-ai/claude-agent-sdk' {
     model: string;
   }
 
-  export type SDKMessage = SDKAssistantMessage | SDKResultMessage | SDKSystemMessage | {
-    type: string;
+  /**
+   * Other message kinds the e2e scripts iterate past but never inspect (user
+   * turns, streaming deltas, ...). The `type` is a constrained set of literals
+   * — NOT an open `type: string` — so `message.type === 'assistant'` still
+   * narrows to SDKAssistantMessage instead of also matching this member.
+   */
+  export interface SDKOtherMessage {
+    type: 'user' | 'stream_event' | 'partial_assistant';
+    uuid?: string;
+    session_id?: string;
     [key: string]: unknown;
-  };
+  }
+
+  export type SDKMessage =
+    | SDKAssistantMessage
+    | SDKResultMessage
+    | SDKSystemMessage
+    | SDKOtherMessage;
 
   export interface Query extends AsyncGenerator<SDKMessage, void> {
     abort(): void;

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,20 @@
+{
+  "//": "Type-check-only config. Compiles both packages in a single non-composite pass with no emit, resolving @chainvault/core from source via the path mapping. Used by `npm run lint` and CI — see issue #33. Do NOT use for building (esbuild does that).",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@chainvault/core": ["./packages/core/src/index.ts"]
+    }
+  },
+  "include": ["packages/core/src/**/*", "packages/cli/src/**/*"]
+}

--- a/tsconfig.check.tests.json
+++ b/tsconfig.check.tests.json
@@ -1,0 +1,20 @@
+{
+  "//": "Type-check-only config for the root tests/ trees (workstyle anvil/fork/testnet suites + agent-e2e scenario scripts). These run under vitest/tsx (esbuild, ESM), so they are checked with bundler resolution rather than the packages' Node16 — see issue #33. No emit. Paired with tsconfig.check.json in `npm run lint`.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"],
+    "paths": {
+      "@chainvault/core": ["./packages/core/src/index.ts"]
+    }
+  },
+  "include": ["tests/**/*.ts"]
+}


### PR DESCRIPTION
## Make the type-check real (#33)

The project's type-check was **vacuous**: `npx tsc --noEmit` (documented + CI)
compiled **0 files** — the root `tsconfig.json` is `"files": []` + project
references with no `--build`. Type errors shipped green all along (a required
`agentId` field missing at 3 call sites passed CI during PR #32 review).

### Why it couldn't just be turned on
A real per-package `tsc` **OOMs at >8.8 GB**. The long-held belief was "viem's
types are too heavy." That is **wrong**. The sole cause is the MCP SDK's
`server.registerTool(...)` generic inferring handler args from `z.object(...)`
schemas — `TS2589: type instantiation excessively deep`, 12 call sites. Proof:
bypass that one inference and cold `tsc` checks the entire core package, viem
and all, in **2.2 s at 0.68 GB**.

### What this does
1. **Typed `registerTool` wrapper** (`mcp/tools/register.ts`) — infers handler
   args itself (`z.infer<Schema>`, one bounded instantiation) and forwards to
   the SDK through a single contained cast. All 16 registrations across 5 tool
   files routed through it. Runtime unchanged (23 tool tests green).
2. **Production fix** — `faucet.ts` `extractTxHash` now rejects a non-string
   `txHash` from an untrusted faucet response (previously `[object Object]`
   could reach the agent-visible message). Was hidden as 3× `TS18046`.
3. **Type-clean the rest** — adapter ABI params widened to `readonly any[]`
   (viem expects readonly; lets const ABIs through; clears 19× `TS4104`); chain
   tool test mocks typed to real signatures (9 more).
4. **Real check wired in** — `tsconfig.check.json` (non-composite, no-emit,
   both packages, path-maps `@chainvault/core` → source) → `npm run lint` +
   CI. Verified **non-vacuous** (catches injected errors) and cross-checked by
   both `tsc` and `tsgo`; ~3 s at 0.7 GB, well under the 7 GB CI runner.
5. **Root `tests/` covered too** — `tsconfig.check.tests.json` (bundler
   resolution, matching vitest/tsx) checks `tests/**`, including the Anvil
   workstyle **PR-gate** suite that no job type-checked before. Fixes 6 real
   `TS2339` errors it surfaced in the agent-e2e scripts (the local
   `claude-agent-sdk` `SDKMessage` union's open `type: string` fallback
   defeated discriminated narrowing).

### Verification
- `npm run lint`: **0 errors** (was: 0 files checked).
- Full unit suite: **448 passed**. `npm run build` (esbuild) unaffected.
- Both `tsc` and `tsgo` agree on 0 errors against `tsconfig.check.json`.

### Note
This also disproves the diagnosis behind #27 (dropped `.d.ts` emission blamed
on viem) — declaration emit may be reversible. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
