### PR TITLE
feat: migrate block-explorer tools to Etherscan V2 + normalize private keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,17 @@ CHAINVAULT_PASSWORD=
 
 # Claude Code OAuth token (required for agent e2e tests in tests/agent-e2e/)
 # CLAUDE_CODE_OAUTH_TOKEN=
+
+# --- Testnet smoke tests (npm run test:testnet, Sepolia) ---
+# A funded Sepolia private key. The 0x prefix is optional (a raw 64-hex key is
+# accepted and normalized). The suite SKIPS unless this key holds >= 0.02 Sepolia
+# ETH. Use a throwaway/dev key with only test funds — never a real one.
+# TESTNET_PRIVATE_KEY=0x...
+#
+# Etherscan API key. OPTIONAL — enables the verify_contract and query_explorer
+# cases. ONE key works for every chain via the Etherscan V2 unified API
+# (https://api.etherscan.io/v2/api); no per-chain key needed.
+# ETHERSCAN_API_KEY=
+#
+# Optional Sepolia RPC override (defaults to a public PublicNode endpoint).
+# TESTNET_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ limit-semantics decision left for a follow-up.
   (api-sepolia.etherscan.io, api.polygonscan.com, ...), which Etherscan has shut
   down. A single Etherscan API key now serves every supported chain — and the 7
   chains that previously had no explorer API (e.g. Base/Arbitrum/Optimism
-  Sepolia, Amoy, Fuji) gain one.
+  Sepolia, Amoy, Fuji) gain one. **Migration:** agents provisioned with a
+  per-chain key (PolygonScan, Arbiscan, ...) must be re-keyed with a single
+  `etherscan` key — the per-chain hosts no longer work. Explorer key matching
+  is also tightened to registrable-domain equality (a key under a look-alike
+  domain like `foo.etherscan.io.evil.com` no longer matches).
 - **Private key normalization:** the vault (`MasterVault.addKey`) now accepts a
   raw 64-hex private key without the `0x` prefix and normalizes it, instead of
   throwing an opaque viem error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ Security hardening (from a verification pass over the March review backlog):
 Deferred: #13 part B (counting deploy gas against spend limits) is a
 limit-semantics decision left for a follow-up.
 
+### Etherscan V2 & key handling
+
+- **Etherscan V2 migration:** `query_explorer` and `verify_contract` now call
+  the unified Etherscan V2 endpoint (`https://api.etherscan.io/v2/api`) with a
+  `chainid` parameter instead of the deprecated per-chain V1 hosts
+  (api-sepolia.etherscan.io, api.polygonscan.com, ...), which Etherscan has shut
+  down. A single Etherscan API key now serves every supported chain — and the 7
+  chains that previously had no explorer API (e.g. Base/Arbitrum/Optimism
+  Sepolia, Amoy, Fuji) gain one.
+- **Private key normalization:** the vault (`MasterVault.addKey`) now accepts a
+  raw 64-hex private key without the `0x` prefix and normalizes it, instead of
+  throwing an opaque viem error.
+
 ## 1.0.1 — 2026-07-20
 
 - **Packaging:** CLI published as `@chainvault/mcp` (scoped; was `chainvault-mcp`).

--- a/docs/testnet-runbook.md
+++ b/docs/testnet-runbook.md
@@ -9,9 +9,15 @@ only and never gates PRs.
 2. Fund it with ~0.05 Sepolia ETH via the faucets registered in the chain
    registry (`list_supported_chains` shows them): Google Cloud faucet,
    pk910 PoW faucet, or Alchemy faucet.
-3. Locally: `TESTNET_PRIVATE_KEY=0x... npm run test:testnet`.
+3. Locally: put the vars in `.env` (see `.env.example`) or inline:
+   `TESTNET_PRIVATE_KEY=0x... npm run test:testnet`. The `0x` prefix is
+   optional — a raw 64-hex key is accepted and normalized.
    CI: set the `TESTNET_PRIVATE_KEY` repo secret (and optionally
-   `ETHERSCAN_API_KEY` for the verify_contract test).
+   `ETHERSCAN_API_KEY` for the verify_contract and query_explorer tests).
+
+The `ETHERSCAN_API_KEY` is a single Etherscan V2 key that works across every
+supported chain via the unified endpoint (`https://api.etherscan.io/v2/api`);
+the per-chain V1 hosts (api-sepolia.etherscan.io, ...) are deprecated.
 
 ## Cost & limits
 - The fixture caps the agent at 0.005 ETH/tx and 0.01 ETH/day; a full run

--- a/packages/core/src/chain/chains.test.ts
+++ b/packages/core/src/chain/chains.test.ts
@@ -6,6 +6,8 @@ import {
   getTestnetChains,
   getMainnetChains,
   getChainsWithFaucets,
+  getExplorerApiUrl,
+  ETHERSCAN_V2_API_URL,
   type ChainConfig,
 } from './chains.js';
 
@@ -177,6 +179,33 @@ describe('Chain Registry', () => {
           expect(faucet.url.length).toBeGreaterThan(0);
           expect(faucet.name.length).toBeGreaterThan(0);
         }
+      }
+    });
+  });
+
+  describe('getExplorerApiUrl (Etherscan V2)', () => {
+    it('returns the unified V2 endpoint for a mainnet chain', () => {
+      expect(getExplorerApiUrl(1)).toBe(ETHERSCAN_V2_API_URL);
+    });
+
+    it('returns the same unified V2 endpoint for Sepolia', () => {
+      expect(getExplorerApiUrl(11155111)).toBe('https://api.etherscan.io/v2/api');
+    });
+
+    it('returns the V2 endpoint for chains that had no explorer API before V2', () => {
+      // e.g. Base Sepolia (84532), Arbitrum Sepolia (421614) — previously had
+      // no apiUrl configured; Etherscan V2 covers them via chainid.
+      expect(getExplorerApiUrl(84532)).toBe(ETHERSCAN_V2_API_URL);
+      expect(getExplorerApiUrl(421614)).toBe(ETHERSCAN_V2_API_URL);
+    });
+
+    it('returns undefined for an unsupported chain', () => {
+      expect(getExplorerApiUrl(999999)).toBeUndefined();
+    });
+
+    it('covers every supported chain (all are on Etherscan V2)', () => {
+      for (const chain of SUPPORTED_CHAINS) {
+        expect(getExplorerApiUrl(chain.chainId)).toBe(ETHERSCAN_V2_API_URL);
       }
     });
   });

--- a/packages/core/src/chain/chains.ts
+++ b/packages/core/src/chain/chains.ts
@@ -22,7 +22,10 @@ export interface ChainConfig {
     websocket?: string[];
     http: string[];
   };
-  blockExplorer?: { name: string; url: string; apiUrl?: string };
+  // `url` is the human-facing explorer (etherscan.io, ...). The programmatic
+  // API base URL is not stored per-chain: every supported chain uses the
+  // unified Etherscan V2 endpoint via getExplorerApiUrl().
+  blockExplorer?: { name: string; url: string };
   faucets?: FaucetConfig[];
 }
 
@@ -42,7 +45,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://ethereum-rpc.publicnode.com'],
       http: ['https://ethereum-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'Etherscan', url: 'https://etherscan.io', apiUrl: 'https://api.etherscan.io' },
+    blockExplorer: { name: 'Etherscan', url: 'https://etherscan.io' },
   },
   {
     chainId: 11155111,
@@ -53,7 +56,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://ethereum-sepolia-rpc.publicnode.com'],
       http: ['https://ethereum-sepolia-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'Etherscan Sepolia', url: 'https://sepolia.etherscan.io', apiUrl: 'https://api-sepolia.etherscan.io' },
+    blockExplorer: { name: 'Etherscan Sepolia', url: 'https://sepolia.etherscan.io' },
     faucets: [
       { name: 'Google Cloud Faucet', url: 'https://cloud.google.com/application/web3/faucet/ethereum/sepolia', type: 'api', requestEndpoint: 'https://cloud.google.com/application/web3/faucet/ethereum/sepolia', method: 'POST' },
       { name: 'Sepolia PoW Faucet', url: 'https://sepolia-faucet.pk910.de', type: 'browser' },
@@ -70,7 +73,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://polygon-bor-rpc.publicnode.com'],
       http: ['https://polygon-bor-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'PolygonScan', url: 'https://polygonscan.com', apiUrl: 'https://api.polygonscan.com' },
+    blockExplorer: { name: 'PolygonScan', url: 'https://polygonscan.com' },
   },
   {
     chainId: 80002,
@@ -98,7 +101,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://arbitrum-one-rpc.publicnode.com'],
       http: ['https://arbitrum-one-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'Arbiscan', url: 'https://arbiscan.io', apiUrl: 'https://api.arbiscan.io' },
+    blockExplorer: { name: 'Arbiscan', url: 'https://arbiscan.io' },
   },
   {
     chainId: 421614,
@@ -125,7 +128,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://optimism-rpc.publicnode.com'],
       http: ['https://optimism-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'Optimism Explorer', url: 'https://optimistic.etherscan.io', apiUrl: 'https://api-optimistic.etherscan.io' },
+    blockExplorer: { name: 'Optimism Explorer', url: 'https://optimistic.etherscan.io' },
   },
   {
     chainId: 11155420,
@@ -152,7 +155,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://base-rpc.publicnode.com'],
       http: ['https://base-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'BaseScan', url: 'https://basescan.org', apiUrl: 'https://api.basescan.org' },
+    blockExplorer: { name: 'BaseScan', url: 'https://basescan.org' },
   },
   {
     chainId: 84532,
@@ -180,7 +183,7 @@ export const SUPPORTED_CHAINS: ReadonlyArray<ChainConfig> = [
       websocket: ['wss://bsc-rpc.publicnode.com'],
       http: ['https://bsc-rpc.publicnode.com'],
     },
-    blockExplorer: { name: 'BscScan', url: 'https://bscscan.com', apiUrl: 'https://api.bscscan.com' },
+    blockExplorer: { name: 'BscScan', url: 'https://bscscan.com' },
   },
   {
     chainId: 97,
@@ -249,4 +252,24 @@ export function getMainnetChains(): ChainConfig[] {
 
 export function getChainsWithFaucets(): ChainConfig[] {
   return SUPPORTED_CHAINS.filter((c) => c.faucets && c.faucets.length > 0);
+}
+
+/**
+ * The Etherscan V2 unified API endpoint. A single endpoint + a single API key
+ * serve every supported chain; the chain is selected with a `chainid` query
+ * parameter. This replaced the per-chain V1 hosts (api-sepolia.etherscan.io,
+ * api.polygonscan.com, api.arbiscan.io, ...), which Etherscan has deprecated.
+ * See https://docs.etherscan.io/v2-migration.
+ */
+export const ETHERSCAN_V2_API_URL = 'https://api.etherscan.io/v2/api';
+
+/**
+ * Returns the block-explorer API base URL for a chain, or undefined if the
+ * chain is not in the supported registry. Every supported chain is covered by
+ * Etherscan V2 (verified against https://api.etherscan.io/v2/chainlist), so
+ * this returns the unified V2 endpoint for all of them; callers must pass the
+ * chain's numeric id as the `chainid` request parameter.
+ */
+export function getExplorerApiUrl(chainId: number): string | undefined {
+  return getChainConfig(chainId) ? ETHERSCAN_V2_API_URL : undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Vault
-export { MasterVault } from './vault/master-vault.js';
+export { MasterVault, normalizePrivateKey } from './vault/master-vault.js';
 export { AgentVaultManager } from './vault/agent-vault.js';
 export {
   encrypt,
@@ -31,6 +31,8 @@ export {
   getTestnetChains,
   getMainnetChains,
   getChainsWithFaucets,
+  getExplorerApiUrl,
+  ETHERSCAN_V2_API_URL,
 } from './chain/chains.js';
 export type { ChainConfig, FaucetConfig } from './chain/chains.js';
 export { requestFaucet, getFaucetInfo } from './chain/faucet.js';

--- a/packages/core/src/mcp/context.test.ts
+++ b/packages/core/src/mcp/context.test.ts
@@ -56,6 +56,16 @@ describe('createAgentContext', () => {
     expect(ctx!.rules).toBeDefined();
   });
 
+  it('resolves the single etherscan key for the unified V2 endpoint', async () => {
+    const ctx = await createAgentContext(testDir, vaultKey);
+    // Under Etherscan V2 one `etherscan` key (base_url api.etherscan.io) serves
+    // every chain via getExplorerApiUrl → https://api.etherscan.io/v2/api.
+    const match = ctx!.getApiKeyForExplorer('https://api.etherscan.io/v2/api');
+    expect(match).not.toBeNull();
+    expect(match!.serviceName).toBe('etherscan');
+    expect(match!.key).toBe('TEST_API_KEY');
+  });
+
   it('context has keys with public addresses only', async () => {
     const ctx = await createAgentContext(testDir, vaultKey);
     expect(ctx!.keys).toHaveLength(1);

--- a/packages/core/src/mcp/context.test.ts
+++ b/packages/core/src/mcp/context.test.ts
@@ -66,6 +66,33 @@ describe('createAgentContext', () => {
     expect(match!.key).toBe('TEST_API_KEY');
   });
 
+  it('does NOT match a deceptive-domain key against the V2 endpoint', async () => {
+    // A key whose base_url merely CONTAINS "etherscan.io" as a subdomain of a
+    // hostile domain must not be sent to the real api.etherscan.io.
+    const vault = await MasterVault.unlock(testDir, TEST_PASSWORD);
+    await vault.addApiKey('evil', 'ATTACKER_SECRET', 'https://foo.etherscan.io.evil.com');
+    const manager = new AgentVaultManager(testDir, vault);
+    const evilCfg: AgentConfig = { ...DEPLOYER_CONFIG, name: 'evil-agent' };
+    const { vaultKey: evilKey } = await manager.createAgent(evilCfg, [], ['evil']);
+    vault.lock();
+
+    const ctx = await createAgentContext(testDir, evilKey);
+    expect(ctx!.getApiKeyForExplorer('https://api.etherscan.io/v2/api')).toBeNull();
+  });
+
+  it('does NOT match a per-chain V1 key (e.g. polygonscan) against the V2 endpoint', async () => {
+    const vault = await MasterVault.unlock(testDir, TEST_PASSWORD);
+    await vault.addApiKey('polygonscan', 'POLY_KEY', 'https://api.polygonscan.com');
+    const manager = new AgentVaultManager(testDir, vault);
+    const cfg: AgentConfig = { ...DEPLOYER_CONFIG, name: 'poly-agent' };
+    const { vaultKey: polyKey } = await manager.createAgent(cfg, [], ['polygonscan']);
+    vault.lock();
+
+    const ctx = await createAgentContext(testDir, polyKey);
+    // Correct under V2 — a polygonscan key genuinely cannot serve the etherscan.io endpoint.
+    expect(ctx!.getApiKeyForExplorer('https://api.etherscan.io/v2/api')).toBeNull();
+  });
+
   it('context has keys with public addresses only', async () => {
     const ctx = await createAgentContext(testDir, vaultKey);
     expect(ctx!.keys).toHaveLength(1);

--- a/packages/core/src/mcp/context.ts
+++ b/packages/core/src/mcp/context.ts
@@ -102,7 +102,11 @@ export async function createAgentContext(
             const explorerHost = new URL(explorerApiUrl).hostname;
             const akDomain = akHost.split('.').slice(-2).join('.');
             const explorerDomain = explorerHost.split('.').slice(-2).join('.');
-            if (akDomain === explorerDomain || akHost.includes(explorerDomain) || explorerHost.includes(akDomain)) {
+            // Registrable-domain equality only. Substring matching is unsafe now
+            // that every explorer URL resolves to api.etherscan.io: a key stored
+            // under `foo.etherscan.io.evil.com` or `scan.io` would otherwise
+            // match and have its secret sent to Etherscan.
+            if (akDomain === explorerDomain) {
               return { serviceName: name, key: ak.key };
             }
           } catch { continue; }

--- a/packages/core/src/mcp/tools/chain-tools.test.ts
+++ b/packages/core/src/mcp/tools/chain-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { registerChainTools, sanitizeError } from './chain-tools.js';
 import type { AgentContext } from '../context.js';
 import type { SimulateResult } from '../../chain/types.js';
@@ -133,6 +133,65 @@ describe('simulate_transaction value conversion', () => {
     expect(simulateTransactionMock).toHaveBeenCalledTimes(1);
     const callArgs = simulateTransactionMock.mock.calls[0][0];
     expect(callArgs.value).toBeUndefined();
+  });
+});
+
+describe('verify_contract Etherscan V2', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function ctxWithExplorerKey(): AgentContext {
+    return {
+      ...createApprovedContext(),
+      getApiKeyForExplorer: () => ({ serviceName: 'etherscan', key: 'SECRET_KEY' }),
+    };
+  }
+
+  it('posts to the unified V2 endpoint with a chainid field', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ status: '1', result: 'GUID' }) });
+    const server = createFakeServer();
+    registerChainTools(server as any, () => ctxWithExplorerKey());
+
+    await server.handlers.get('verify_contract')!({
+      chain_id: 11155111,
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      source_code: 'contract C {}',
+      contract_name: 'C',
+      compiler_version: '0.8.24',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    // V2 endpoint used verbatim — NOT the old `${apiUrl}/api` V1 shape.
+    expect(String(url)).toBe('https://api.etherscan.io/v2/api');
+    expect(String(url)).not.toContain('api-sepolia.etherscan.io');
+    const body = String((init as { body: string }).body);
+    expect(body).toContain('chainid=11155111');
+    expect(body).toContain('action=verifysourcecode');
+  });
+
+  it('denies verification on an unsupported chain without any fetch', async () => {
+    const server = createFakeServer();
+    registerChainTools(server as any, () => ctxWithExplorerKey());
+
+    const res = await server.handlers.get('verify_contract')!({
+      chain_id: 999999,
+      address: '0xabc',
+      source_code: 'x',
+      contract_name: 'C',
+      compiler_version: '0.8.24',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.content[0].text).toMatch(/no block explorer/i);
   });
 });
 

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -3,7 +3,7 @@ import { parseEther } from 'viem';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTool } from './register.js';
 import { EvmAdapter } from '../../chain/evm-adapter.js';
-import { getChainConfig, getExplorerApiUrl } from '../../chain/chains.js';
+import { getExplorerApiUrl } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
 import { sanitizeError } from './sanitize.js';
@@ -193,9 +193,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
       // Find an API key for this explorer via controlled accessor
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
-        const explorerName = getChainConfig(chain_id)?.blockExplorer?.name ?? 'the block explorer';
         audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No API key for explorer' });
-        return { content: [{ type: 'text' as const, text: `No API key configured for ${explorerName}. Add one via the TUI or CLI.` }] };
+        return { content: [{ type: 'text' as const, text: `No Etherscan API key configured for chain ${chain_id}. Add a single 'etherscan' key — Etherscan V2 covers every chain — via the TUI or CLI.` }] };
       }
 
       try {

--- a/packages/core/src/mcp/tools/chain-tools.ts
+++ b/packages/core/src/mcp/tools/chain-tools.ts
@@ -3,7 +3,7 @@ import { parseEther } from 'viem';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTool } from './register.js';
 import { EvmAdapter } from '../../chain/evm-adapter.js';
-import { getChainConfig } from '../../chain/chains.js';
+import { getChainConfig, getExplorerApiUrl } from '../../chain/chains.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
 import { sanitizeError } from './sanitize.js';
@@ -182,23 +182,25 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
         return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
       }
 
-      // Find explorer API URL from chain config
-      const chainConfig = getChainConfig(chain_id);
-      if (!chainConfig?.blockExplorer?.apiUrl) {
+      // Every supported chain is served by the unified Etherscan V2 endpoint;
+      // the chain is selected with the chainid field in the request body.
+      const explorerApiUrl = getExplorerApiUrl(chain_id);
+      if (!explorerApiUrl) {
         audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No explorer API for chain' });
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
       // Find an API key for this explorer via controlled accessor
-      const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
+        const explorerName = getChainConfig(chain_id)?.blockExplorer?.name ?? 'the block explorer';
         audit({ action: 'verify_contract', chain_id, status: 'denied', details: 'No API key for explorer' });
-        return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
+        return { content: [{ type: 'text' as const, text: `No API key configured for ${explorerName}. Add one via the TUI or CLI.` }] };
       }
 
       try {
         const params = new URLSearchParams({
+          chainid: String(chain_id),
           apikey: apiKeyMatch.key,
           module: 'contract',
           action: 'verifysourcecode',
@@ -210,7 +212,8 @@ export function registerChainTools(server: McpServer, getContext: ContextGetter,
           optimizationUsed: optimization ? '1' : '0',
         });
 
-        const response = await fetch(`${explorerApiUrl}/api`, {
+        // explorerApiUrl already includes the /v2/api path.
+        const response = await fetch(explorerApiUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: params.toString(),

--- a/packages/core/src/mcp/tools/proxy-tools.test.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.test.ts
@@ -113,6 +113,31 @@ describe('query_explorer Etherscan V2', () => {
     expect(res.content[0].text).toContain('ok');
   });
 
+  it('does not let params override the whitelisted action/module/chainid', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ status: '1', result: 'ok' }) });
+    const server = createFakeServer();
+    registerProxyTools(server, () => createExplorerContext(), vi.fn());
+
+    // Agent passes a crafted params trying to swap the checked action + chain.
+    await server.handlers.get('query_explorer')({
+      chain_id: 11155111,
+      module: 'contract',
+      action: 'getabi',
+      params: { action: 'txlist', module: 'account', chainid: '1', address: '0xabc' },
+    });
+
+    const url = String(fetchMock.mock.calls[0][0]);
+    // The trusted values win; the override attempt does not reach Etherscan.
+    expect(url).toContain('action=getabi');
+    expect(url).toContain('module=contract');
+    expect(url).toContain('chainid=11155111');
+    expect(url).not.toContain('action=txlist');
+    expect(url).not.toContain('chainid=1&');
+    expect(url).not.toMatch(/chainid=1$/);
+    // legitimate extra params still flow through
+    expect(url).toContain('address=0xabc');
+  });
+
   it('denies an unsupported chain without any external call', async () => {
     const server = createFakeServer();
     const audit = vi.fn();

--- a/packages/core/src/mcp/tools/proxy-tools.test.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.test.ts
@@ -53,3 +53,78 @@ describe('query_price access control', () => {
     expect(res.content[0].text).toContain('3000');
   });
 });
+
+/** Context with a single Etherscan key that serves all chains (V2 model). */
+function createExplorerContext(): AgentContext {
+  return {
+    agentName: 'explorer-agent',
+    config: { api_access: { etherscan: {} } } as unknown as AgentContext['config'],
+    rules: { checkApiRequest: () => ({ approved: true }) } as unknown as AgentContext['rules'],
+    keys: [],
+    getPrivateKeyForChain: () => null,
+    getApiKey: () => null,
+    getApiKeyForExplorer: () => ({ serviceName: 'etherscan', key: 'SECRET_KEY' }),
+    getRpcUrlForChain: () => null,
+  };
+}
+
+describe('query_explorer Etherscan V2', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('calls the unified V2 endpoint with a chainid param for Sepolia', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ status: '1', result: 'ok' }) });
+    const server = createFakeServer();
+    registerProxyTools(server, () => createExplorerContext(), vi.fn());
+
+    await server.handlers.get('query_explorer')({
+      chain_id: 11155111,
+      module: 'contract',
+      action: 'getabi',
+      params: { address: '0xabc' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('https://api.etherscan.io/v2/api');
+    expect(url).toContain('chainid=11155111');
+    expect(url).toContain('module=contract');
+    expect(url).toContain('action=getabi');
+    expect(url).toContain('address=0xabc');
+    // must NOT hit the deprecated V1 host
+    expect(url).not.toContain('api-sepolia.etherscan.io');
+  });
+
+  it('sends the chain-specific chainid for a chain that had no V1 API (Base Sepolia)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ status: '1', result: 'ok' }) });
+    const server = createFakeServer();
+    registerProxyTools(server, () => createExplorerContext(), vi.fn());
+
+    const res = await server.handlers.get('query_explorer')({
+      chain_id: 84532,
+      module: 'account',
+      action: 'balance',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('chainid=84532');
+    expect(res.content[0].text).toContain('ok');
+  });
+
+  it('denies an unsupported chain without any external call', async () => {
+    const server = createFakeServer();
+    const audit = vi.fn();
+    registerProxyTools(server, () => createExplorerContext(), audit);
+
+    const res = await server.handlers.get('query_explorer')({
+      chain_id: 999999,
+      module: 'contract',
+      action: 'getabi',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.content[0].text).toMatch(/no block explorer/i);
+  });
+});

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTool } from './register.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
-import { getChainConfig } from '../../chain/chains.js';
+import { getChainConfig, getExplorerApiUrl } from '../../chain/chains.js';
 import { ApiProxy } from '../../proxy/api-proxy.js';
 import { sanitizeError } from './sanitize.js';
 
@@ -32,19 +32,20 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter,
         return { content: [{ type: 'text' as const, text: 'No agent context. Set CHAINVAULT_VAULT_KEY.' }] };
       }
 
-      // Find explorer API URL from chain config
-      const chainConfig = getChainConfig(chain_id);
-      if (!chainConfig?.blockExplorer?.apiUrl) {
+      // Every supported chain is served by the unified Etherscan V2 endpoint;
+      // the chain is selected with the chainid param below.
+      const explorerApiUrl = getExplorerApiUrl(chain_id);
+      if (!explorerApiUrl) {
         audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No explorer API for chain' });
         return { content: [{ type: 'text' as const, text: `No block explorer API configured for chain ${chain_id}.` }] };
       }
 
       // Find API key matching this explorer via controlled accessor
-      const explorerApiUrl = chainConfig.blockExplorer.apiUrl;
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
+        const explorerName = getChainConfig(chain_id)?.blockExplorer?.name ?? 'the block explorer';
         audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No API key for explorer' });
-        return { content: [{ type: 'text' as const, text: `No API key configured for ${chainConfig.blockExplorer.name}. Add one via the TUI or CLI.` }] };
+        return { content: [{ type: 'text' as const, text: `No API key configured for ${explorerName}. Add one via the TUI or CLI.` }] };
       }
       const { serviceName, key: apiKeyValue } = apiKeyMatch;
 
@@ -61,9 +62,10 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter,
       try {
         const result = await proxy.request({
           agentId: ctx.agentName,
+          // explorerApiUrl already includes the /v2/api path.
           baseUrl: explorerApiUrl,
-          endpoint: '/api',
-          params: { module: mod, action, ...(extraParams ?? {}) },
+          endpoint: '',
+          params: { chainid: String(chain_id), module: mod, action, ...(extraParams ?? {}) },
           apiKey: apiKeyValue,
           rateLimits,
         });

--- a/packages/core/src/mcp/tools/proxy-tools.ts
+++ b/packages/core/src/mcp/tools/proxy-tools.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTool } from './register.js';
 import type { AgentContext } from '../context.js';
 import type { AuditFn } from '../audit-fn.js';
-import { getChainConfig, getExplorerApiUrl } from '../../chain/chains.js';
+import { getExplorerApiUrl } from '../../chain/chains.js';
 import { ApiProxy } from '../../proxy/api-proxy.js';
 import { sanitizeError } from './sanitize.js';
 
@@ -43,9 +43,8 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter,
       // Find API key matching this explorer via controlled accessor
       const apiKeyMatch = ctx.getApiKeyForExplorer(explorerApiUrl);
       if (!apiKeyMatch) {
-        const explorerName = getChainConfig(chain_id)?.blockExplorer?.name ?? 'the block explorer';
         audit({ action: 'query_explorer', chain_id, status: 'denied', details: 'No API key for explorer' });
-        return { content: [{ type: 'text' as const, text: `No API key configured for ${explorerName}. Add one via the TUI or CLI.` }] };
+        return { content: [{ type: 'text' as const, text: `No Etherscan API key configured for chain ${chain_id}. Add a single 'etherscan' key — Etherscan V2 covers every chain — via the TUI or CLI.` }] };
       }
       const { serviceName, key: apiKeyValue } = apiKeyMatch;
 
@@ -65,7 +64,10 @@ export function registerProxyTools(server: McpServer, getContext: ContextGetter,
           // explorerApiUrl already includes the /v2/api path.
           baseUrl: explorerApiUrl,
           endpoint: '',
-          params: { chainid: String(chain_id), module: mod, action, ...(extraParams ?? {}) },
+          // Spread agent-supplied params FIRST so the trusted chainid/module/
+          // action (the ones the rules engine checked) always win and can't be
+          // overridden by a crafted `params` entry.
+          params: { ...(extraParams ?? {}), chainid: String(chain_id), module: mod, action },
           apiKey: apiKeyValue,
           rateLimits,
         });

--- a/packages/core/src/vault/master-vault.test.ts
+++ b/packages/core/src/vault/master-vault.test.ts
@@ -77,6 +77,27 @@ describe('MasterVault', () => {
       expect(keys[0]).not.toHaveProperty('private_key');
     });
 
+    it('accepts a private key without the 0x prefix and normalizes it', async () => {
+      await MasterVault.init(testDir, 'test-password');
+      vault = await MasterVault.unlock(testDir, 'test-password', { autoLockMs: 0 });
+      // Same key as above but with no 0x prefix — a common paste mistake.
+      await vault.addKey('raw-key', 'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', [1]);
+      const keys = vault.listKeys();
+      expect(keys).toHaveLength(1);
+      // Must derive the SAME address as the 0x-prefixed form (Anvil account #0).
+      expect(keys[0].address).toBe('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+      // The stored private key must be normalized to 0x-prefixed so downstream
+      // signing (viem privateKeyToAccount) works.
+      const stored = vault.getData().keys['raw-key'].private_key;
+      expect(stored).toBe('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80');
+    });
+
+    it('rejects a private key that is not valid hex even after normalization', async () => {
+      await MasterVault.init(testDir, 'test-password');
+      vault = await MasterVault.unlock(testDir, 'test-password', { autoLockMs: 0 });
+      await expect(vault.addKey('bad', 'not-a-valid-hex-key', [1])).rejects.toThrow();
+    });
+
     it('removes a key', async () => {
       await MasterVault.init(testDir, 'test-password');
       vault = await MasterVault.unlock(testDir, 'test-password', { autoLockMs: 0 });

--- a/packages/core/src/vault/master-vault.test.ts
+++ b/packages/core/src/vault/master-vault.test.ts
@@ -92,6 +92,16 @@ describe('MasterVault', () => {
       expect(stored).toBe('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80');
     });
 
+    it('normalizes an uppercase 0X prefix to a lowercase 0x key', async () => {
+      await MasterVault.init(testDir, 'test-password');
+      vault = await MasterVault.unlock(testDir, 'test-password', { autoLockMs: 0 });
+      await vault.addKey('upper', '0Xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', [1]);
+      expect(vault.getData().keys['upper'].private_key).toBe(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+      expect(vault.listKeys()[0].address).toBe('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+    });
+
     it('rejects a private key that is not valid hex even after normalization', async () => {
       await MasterVault.init(testDir, 'test-password');
       vault = await MasterVault.unlock(testDir, 'test-password', { autoLockMs: 0 });

--- a/packages/core/src/vault/master-vault.ts
+++ b/packages/core/src/vault/master-vault.ts
@@ -14,8 +14,12 @@ const SALT_FILENAME = 'master.salt';
  * `privateKeyToAddress`, which throws on anything that isn't a valid key.
  */
 export function normalizePrivateKey(privateKey: string): `0x${string}` {
-  const trimmed = privateKey.trim();
-  return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as `0x${string}`;
+  // Strip a case-insensitive 0x/0X prefix and re-add a lowercase one, so
+  // `0X…`, `0x…`, and a bare `…` all yield the lowercase-prefixed form viem
+  // expects. Internal whitespace / non-hex is left for privateKeyToAddress to
+  // reject rather than silently stripped.
+  const body = privateKey.trim().replace(/^0x/i, '');
+  return `0x${body}` as `0x${string}`;
 }
 
 export class MasterVault {

--- a/packages/core/src/vault/master-vault.ts
+++ b/packages/core/src/vault/master-vault.ts
@@ -7,6 +7,17 @@ import { MasterVaultDataSchema, type MasterVaultData } from './types.js';
 const VAULT_FILENAME = 'master.vault';
 const SALT_FILENAME = 'master.salt';
 
+/**
+ * Normalizes a private key to the 0x-prefixed form viem requires. Accepts a
+ * raw 64-hex key (a common paste from key exports that omit the prefix) and
+ * trims surrounding whitespace. Does NOT validate hex — that is left to
+ * `privateKeyToAddress`, which throws on anything that isn't a valid key.
+ */
+export function normalizePrivateKey(privateKey: string): `0x${string}` {
+  const trimmed = privateKey.trim();
+  return (trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`) as `0x${string}`;
+}
+
 export class MasterVault {
   private data: MasterVaultData | null = null;
   private masterKey: Buffer | null = null;
@@ -102,8 +113,10 @@ export class MasterVault {
 
   async addKey(name: string, privateKey: string, chains: number[]): Promise<void> {
     const data = this.requireUnlocked();
-    const address = privateKeyToAddress(privateKey as `0x${string}`);
-    data.keys[name] = { private_key: privateKey, address, chains };
+    const normalized = normalizePrivateKey(privateKey);
+    // Throws on anything that isn't a valid 32-byte hex key.
+    const address = privateKeyToAddress(normalized);
+    data.keys[name] = { private_key: normalized, address, chains };
     await this.save();
   }
 

--- a/tests/workstyle/testnet/sepolia.test.ts
+++ b/tests/workstyle/testnet/sepolia.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createPublicClient, http, formatEther } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import { normalizePrivateKey } from '@chainvault/core';
 import { compileCorpusContract, compilerAvailable } from '../helpers/corpus.js';
 import { createVaultFixture, type VaultFixture } from '../helpers/vault-fixture.js';
 import { connectMcp, callToolJson, callToolText, type WorkstyleMcp } from '../helpers/mcp.js';
@@ -10,10 +11,13 @@ const SEPOLIA = 11155111;
 const SEPOLIA_RPC = process.env.TESTNET_RPC_URL ?? 'https://ethereum-sepolia-rpc.publicnode.com';
 const MIN_BALANCE_ETH = 0.02;
 
-const key = process.env.TESTNET_PRIVATE_KEY;
+// Accept a raw 64-hex key (no 0x) from the env — normalize the same way the vault does.
+const key = process.env.TESTNET_PRIVATE_KEY
+  ? normalizePrivateKey(process.env.TESTNET_PRIVATE_KEY)
+  : undefined;
 let funded = false;
 if (key) {
-  const account = privateKeyToAccount(key as `0x${string}`);
+  const account = privateKeyToAccount(key);
   const client = createPublicClient({ transport: http(SEPOLIA_RPC) });
   try {
     const balance = await client.getBalance({ address: account.address });
@@ -36,7 +40,8 @@ describe.skipIf(!ready)('Sepolia live smoke', () => {
       chainId: SEPOLIA,
       keys: { 'testnet-key': { privateKey: key!, chains: [SEPOLIA] } },
       apiKeys: process.env.ETHERSCAN_API_KEY
-        ? { etherscan: { key: process.env.ETHERSCAN_API_KEY, baseUrl: 'https://api-sepolia.etherscan.io' } }
+        // One Etherscan V2 key serves every chain via the unified endpoint.
+        ? { etherscan: { key: process.env.ETHERSCAN_API_KEY, baseUrl: 'https://api.etherscan.io' } }
         : {},
       agents: [{
         name: 'testnet-agent',
@@ -71,12 +76,19 @@ describe.skipIf(!ready)('Sepolia live smoke', () => {
   });
 
   it('interacts and reads events back', async () => {
-    const account = privateKeyToAccount(key! as `0x${string}`);
+    const account = privateKeyToAccount(key!);
     const write = await callToolJson(mcp.client, 'interact_contract', {
       chain_id: SEPOLIA, address: tokenAddress, abi: tokenAbi,
       function_name: 'transfer', args: [account.address, '1'],
     });
     expect(write.hash).toMatch(/^0x/);
+    // The tx is broadcast but not necessarily mined yet — wait for the receipt
+    // before asking the tool for it, or get_transaction races the network.
+    const publicClient = createPublicClient({ transport: http(SEPOLIA_RPC) });
+    await publicClient.waitForTransactionReceipt({
+      hash: write.hash as `0x${string}`,
+      timeout: 120_000,
+    });
     const tx = await callToolJson(mcp.client, 'get_transaction', {
       chain_id: SEPOLIA, hash: write.hash,
     });
@@ -99,9 +111,12 @@ describe.skipIf(!ready)('Sepolia live smoke', () => {
     expect(text.toLowerCase()).toMatch(/guid|pending|submitted|verified|ok/);
   });
 
-  it.skipIf(!process.env.ETHERSCAN_API_KEY)('query_explorer fetches the deploy tx through the vault API key', async () => {
+  it.skipIf(!process.env.ETHERSCAN_API_KEY)('query_explorer fetches the deploy receipt through the vault API key', async () => {
+    // Query the receipt, not the transaction: a contract-creation tx has
+    // `to: null` and does not contain the deployed address — that only appears
+    // as `contractAddress` in the receipt.
     const text = await callToolText(mcp.client, 'query_explorer', {
-      chain_id: SEPOLIA, module: 'proxy', action: 'eth_getTransactionByHash',
+      chain_id: SEPOLIA, module: 'proxy', action: 'eth_getTransactionReceipt',
       params: { txhash: deployHash },
     });
     expect(text.toLowerCase()).toContain(tokenAddress.toLowerCase().slice(2, 10));


### PR DESCRIPTION
## Migrate block-explorer tools to Etherscan V2 + normalize private keys

> **Stacked on #34** (`fix/typecheck-gate-33`). Review/merge #34 first; this PR's
> base retargets to `main` automatically once #34 lands.

### Why
Etherscan shut down the per-chain V1 API hosts. A live `query_explorer` call now
returns:
> `"you are using a deprecated v1 endpoint, switch to etherscan api v2"`

Etherscan V2 is one unified endpoint — `https://api.etherscan.io/v2/api` — with
the chain selected by a `chainid` param and **a single API key for all chains**.

### What
- **`chains.ts`** — add `ETHERSCAN_V2_API_URL` + `getExplorerApiUrl(chainId)`;
  remove the now-dead per-chain `blockExplorer.apiUrl` (all 14 supported chains
  are on V2, verified against `/v2/chainlist`).
- **`query_explorer` + `verify_contract`** — resolve the URL via
  `getExplorerApiUrl` and send `chainid`. A single `etherscan` vault key now
  serves every chain, and **7 chains that had no explorer API before** (Base /
  Arbitrum / Optimism Sepolia, Amoy, Fuji, ...) gain one.
- **Key normalization** — `MasterVault.addKey` accepts a raw 64-hex private key
  without the `0x` prefix (a common paste mistake) and normalizes it, instead of
  throwing an opaque viem error.
- **Testnet suite** — fixture points at the V2 key; the receipt read now waits
  for the tx to mine (was a race); the `query_explorer` case reads the deploy
  **receipt** (which carries `contractAddress`) instead of the transaction
  (whose `to` is `null` for a deploy).
- **Docs** — `.env.example` now documents `TESTNET_PRIVATE_KEY` /
  `ETHERSCAN_API_KEY` / `TESTNET_RPC_URL` (0x optional, one V2 key), plus the
  runbook and changelog.

### Verification
- `npm run lint`: **0 errors**. Unit: **461 passed**. Workstyle (anvil PR gate):
  **54 passed**.
- **Live Sepolia + Etherscan V2, real key: all 5 testnet tests pass** — deploy,
  interact+read, verify_contract, query_explorer, query_price. Confirmed the V2
  endpoint returns real data where V1 returned the deprecation error.
- V2 request shape grounded in live probes (`/v2/api?chainid=11155111&...`
  returned `status:1 OK`), not just docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
